### PR TITLE
feat: add web vitals ingestion pipeline

### DIFF
--- a/app/api/monitoring/vitals/route.ts
+++ b/app/api/monitoring/vitals/route.ts
@@ -1,0 +1,144 @@
+/**
+ * Receives Web Vitals metrics from the client and forwards them to monitoring sinks.
+ * Metrics are accepted only as JSON POST requests to keep the surface minimal.
+ */
+
+import { createApiLogger } from '@/lib/utils/api-logger';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  ErrorCodes,
+} from '@/lib/utils/api-response';
+import {
+  createRequestContextFromNextRequest,
+  getOrCreateRequestId,
+} from '@/lib/utils/request-id';
+import { isTelemetryConsentGranted } from '@/lib/monitoring/privacy';
+import { NextRequest } from 'next/server';
+
+interface IncomingWebVitalPayload {
+  name?: unknown;
+  value?: unknown;
+  id?: unknown;
+  label?: unknown;
+  path?: unknown;
+  href?: unknown;
+  navigationType?: unknown;
+}
+
+function sanitizePayload(payload: IncomingWebVitalPayload) {
+  const metricName =
+    typeof payload.name === 'string' ? payload.name : undefined;
+  const metricValue =
+    typeof payload.value === 'number' ? payload.value : undefined;
+
+  if (
+    !metricName ||
+    typeof metricValue !== 'number' ||
+    !Number.isFinite(metricValue)
+  ) {
+    return undefined;
+  }
+
+  return {
+    name: metricName,
+    value: metricValue,
+    id: typeof payload.id === 'string' ? payload.id : undefined,
+    label: typeof payload.label === 'string' ? payload.label : undefined,
+    path: typeof payload.path === 'string' ? payload.path : undefined,
+    href: typeof payload.href === 'string' ? payload.href : undefined,
+    navigationType:
+      typeof payload.navigationType === 'string'
+        ? payload.navigationType
+        : undefined,
+  } as const;
+}
+
+export async function POST(request: NextRequest) {
+  const requestId = getOrCreateRequestId(request);
+  const context = createRequestContextFromNextRequest(request, requestId);
+  const logger = createApiLogger(context);
+
+  if (!request.headers.get('content-type')?.includes('application/json')) {
+    logger.warn('Rejected web vitals payload without JSON content type');
+    logger.trackRequestCompletion(415);
+    return createErrorResponse(
+      'Unsupported Media Type. Expected application/json payload.',
+      ErrorCodes.INVALID_INPUT,
+      requestId,
+      415
+    );
+  }
+
+  let rawPayload: IncomingWebVitalPayload;
+
+  try {
+    rawPayload = (await request.json()) as IncomingWebVitalPayload;
+  } catch (error) {
+    logger.warn('Failed to parse web vitals payload', { error });
+    logger.trackRequestCompletion(400);
+    return createErrorResponse(
+      'Invalid JSON payload.',
+      ErrorCodes.INVALID_INPUT,
+      requestId,
+      400
+    );
+  }
+
+  const metric = sanitizePayload(rawPayload);
+
+  if (!metric) {
+    logger.warn('Rejected web vitals payload due to missing name/value');
+    logger.trackRequestCompletion(400);
+    return createErrorResponse(
+      'Metric name and value are required.',
+      ErrorCodes.INVALID_INPUT,
+      requestId,
+      400
+    );
+  }
+
+  const telemetryAllowed = isTelemetryConsentGranted();
+  const sanitizedMetric = {
+    ...metric,
+    href: telemetryAllowed ? metric.href : undefined,
+  } as const;
+
+  const eventData = {
+    ...sanitizedMetric,
+    consentGranted: telemetryAllowed,
+    source: 'web-vitals',
+  } as const;
+
+  logger.info('Accepted web vitals metric', {
+    name: metric.name,
+    value: metric.value,
+    path: metric.path,
+    label: metric.label,
+  });
+
+  logger.trackBusinessEvent('web_vitals_metric', {
+    metric: metric.name,
+    value: metric.value,
+    path: metric.path,
+    label: metric.label,
+    navigationType: metric.navigationType,
+  });
+
+  logger.trackRequestCompletion(202);
+
+  return createSuccessResponse(
+    { accepted: true, event: eventData },
+    requestId,
+    202
+  );
+}
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      Allow: 'OPTIONS, POST',
+    },
+  });
+}

--- a/components/MonitoringInit.tsx
+++ b/components/MonitoringInit.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import {
+  initWebVitals,
+  type WebVitalMetric,
+} from '@/lib/monitoring/web-vitals';
+import { usePathname } from 'next/navigation';
+import * as React from 'react';
+
+function sendMetric(metric: WebVitalMetric & { path?: string }) {
+  const payload = JSON.stringify({
+    name: metric.name,
+    value: metric.value,
+    id: metric.id,
+    label: metric.label,
+    path: metric.path,
+    timestamp: new Date().toISOString(),
+  });
+
+  try {
+    if (
+      typeof navigator !== 'undefined' &&
+      typeof navigator.sendBeacon === 'function'
+    ) {
+      const blob = new Blob([payload], { type: 'application/json' });
+      navigator.sendBeacon('/api/monitoring/vitals', blob);
+      return;
+    }
+  } catch {
+    // navigator.sendBeacon failed, fall back to fetch keepalive below
+  }
+
+  void fetch('/api/monitoring/vitals', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: payload,
+    keepalive: true,
+  }).catch(() => {
+    // Swallow network errors for telemetry to avoid impacting UX
+  });
+}
+
+export default function MonitoringInit() {
+  const pathname = usePathname();
+  const initializedRef = React.useRef(new Set<string>());
+
+  React.useEffect(() => {
+    if (!pathname || initializedRef.current.has(pathname)) {
+      return;
+    }
+
+    let subscribed = true;
+
+    const setup = async () => {
+      const initialized = await initWebVitals(
+        metric => {
+          if (!subscribed) return;
+          sendMetric({ ...metric, path: pathname });
+        },
+        { path: pathname }
+      );
+
+      if (initialized) {
+        initializedRef.current.add(pathname);
+      }
+    };
+
+    void setup();
+
+    return () => {
+      subscribed = false;
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -6,6 +6,7 @@ import ClerkProviderWrapper from '@/components/auth/ClerkProviderWrapper';
 import StripeProvider from '@/components/payment/StripeProvider';
 import ConditionalPublicNavigation from '@/components/navigation/ConditionalPublicNavigation';
 import { RollbarProviderWrapper } from '@/lib/monitoring/rollbar-react-official';
+import MonitoringInit from '@/components/MonitoringInit';
 import * as React from 'react';
 
 type ProvidersProps = {
@@ -22,6 +23,7 @@ export default function Providers({ children, isE2E }: ProvidersProps) {
           <ErrorBoundary>
             <ConditionalPublicNavigation />
             {children}
+            <MonitoringInit />
           </ErrorBoundary>
         </ThemeRegistry>
       ) : (
@@ -31,6 +33,7 @@ export default function Providers({ children, isE2E }: ProvidersProps) {
               <ErrorBoundary>
                 <ConditionalPublicNavigation />
                 {children}
+                <MonitoringInit />
               </ErrorBoundary>
             </StripeProvider>
           </ThemeRegistry>


### PR DESCRIPTION
### **User description**
## Summary
- add MonitoringInit client to stream web vitals metrics via sendBeacon/fetch
- register MonitoringInit inside Providers so it runs in all modes
- implement /api/monitoring/vitals POST handler with validation and consent gating

## Testing
- npm run lint


___

### **PR Type**
Enhancement


___

### **Description**
- Add Web Vitals ingestion pipeline with client-side metric collection

- Implement `/api/monitoring/vitals` POST endpoint with validation

- Enforce consent-based telemetry gating for sensitive data

- Register `MonitoringInit` component in all app modes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Client["Client: MonitoringInit"] -->|sendBeacon/fetch| API["API: /api/monitoring/vitals"]
  API -->|validate & sanitize| Processor["Payload Processor"]
  Processor -->|check consent| Logger["Logger: Track Event"]
  Logger -->|202 Accepted| Response["Success Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Web Vitals API endpoint with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/monitoring/vitals/route.ts

<ul><li>Implements POST handler to receive Web Vitals metrics from client<br> <li> Validates incoming JSON payload with strict type checking<br> <li> Sanitizes metric data and enforces consent-based href filtering<br> <li> Logs accepted metrics and tracks business events with request <br>completion</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/24/files#diff-0ee4b67e5bc6e804c12b56e99a69007cc557e9fbd2be4f5b1e0af47b6494e4ea">+144/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MonitoringInit.tsx</strong><dd><code>Client-side Web Vitals metric collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/MonitoringInit.tsx

<ul><li>Client-side component that initializes Web Vitals collection<br> <li> Sends metrics via <code>navigator.sendBeacon</code> with fetch fallback<br> <li> Tracks pathname per route and prevents duplicate initialization<br> <li> Gracefully handles network errors to avoid UX impact</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/24/files#diff-356435677c305441bcf680188b5ff51208f2a9598e81984d939e07d25ab2c544">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Providers.tsx</strong><dd><code>Register MonitoringInit in provider tree</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/Providers.tsx

<ul><li>Imports and registers <code>MonitoringInit</code> component<br> <li> Adds <code>MonitoringInit</code> to both E2E and production provider trees<br> <li> Ensures Web Vitals collection runs in all application modes</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/24/files#diff-3d8bd54f17bd61a7eb98b225f40a96a94f7f9b3177984c291b362ef7364e66b4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

