### PR TITLE
Fix production E2E base URL and academy metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -482,6 +482,7 @@ jobs:
         run: npx playwright test --project=chromium
         env:
           PLAYWRIGHT_BASE_URL: ${{ env.PRODUCTION_ALIAS }}
+          NEXT_PUBLIC_APP_URL: ${{ env.PRODUCTION_ALIAS }}
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/app/academy/page.tsx
+++ b/app/academy/page.tsx
@@ -44,7 +44,7 @@ export const metadata: Metadata = {
 export const dynamic = 'force-static';
 
 export default function AcademyPage() {
-  const jsonLdSchemas = SCHEMA_COMBINATIONS.aboutPage();
+  const jsonLdSchemas = SCHEMA_COMBINATIONS.academyPage();
   return (
     <>
       {jsonLdSchemas.map((schema, index) => (

--- a/lib/seo/schemas.ts
+++ b/lib/seo/schemas.ts
@@ -213,6 +213,20 @@ export const SCHEMA_COMBINATIONS = {
     ]),
     ...courses.map(course => generateCourseSchema(course)),
   ],
+  academyPage: () => [
+    generateOrganizationSchema(),
+    generateWebPageSchema({
+      title: `Hemera Academy – Über unsere Kurse`,
+      description:
+        'Erfahre mehr über die Hemera Academy: Ziele, Lernformate und wie du mit unseren Kursen durchstartest.',
+      url: `${ORGANIZATION_CONFIG.url}/academy`,
+      type: 'WebPage',
+    }),
+    generateBreadcrumbSchema([
+      { name: 'Home', url: ORGANIZATION_CONFIG.url },
+      { name: 'Academy', url: `${ORGANIZATION_CONFIG.url}/academy` },
+    ]),
+  ],
   aboutPage: () => [
     generateOrganizationSchema(),
     generateWebPageSchema({

--- a/tests/e2e/admin-api.spec.ts
+++ b/tests/e2e/admin-api.spec.ts
@@ -10,13 +10,11 @@ import { expect, test } from '@playwright/test';
  * - Return proper error responses
  */
 
-const baseURL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-
 test.describe('Admin API Authentication & Authorization', () => {
   test('GET /api/admin/users - should require authentication', async ({
     request,
   }) => {
-    const response = await request.get(`${baseURL}/api/admin/users`);
+    const response = await request.get('/api/admin/users');
 
     // Should return 401 Unauthorized
     expect(response.status()).toBe(401);
@@ -30,7 +28,7 @@ test.describe('Admin API Authentication & Authorization', () => {
   test('GET /api/admin/courses - should require authentication', async ({
     request,
   }) => {
-    const response = await request.get(`${baseURL}/api/admin/courses`);
+    const response = await request.get('/api/admin/courses');
 
     // Should return 401 Unauthorized
     expect(response.status()).toBe(401);
@@ -44,7 +42,7 @@ test.describe('Admin API Authentication & Authorization', () => {
   test('GET /api/admin/analytics - should require authentication', async ({
     request,
   }) => {
-    const response = await request.get(`${baseURL}/api/admin/analytics`);
+    const response = await request.get('/api/admin/analytics');
 
     // Should return 401 Unauthorized
     expect(response.status()).toBe(401);
@@ -58,7 +56,7 @@ test.describe('Admin API Authentication & Authorization', () => {
   test('GET /api/admin/errors - should require authentication', async ({
     request,
   }) => {
-    const response = await request.get(`${baseURL}/api/admin/errors`);
+    const response = await request.get('/api/admin/errors');
 
     // Should return 401 Unauthorized
     expect(response.status()).toBe(401);
@@ -74,7 +72,7 @@ test.describe('Admin API CORS Support', () => {
   test('OPTIONS /api/admin/users - should handle preflight request', async ({
     request,
   }) => {
-    const response = await request.fetch(`${baseURL}/api/admin/users`, {
+    const response = await request.fetch('/api/admin/users', {
       method: 'OPTIONS',
     });
 
@@ -91,7 +89,7 @@ test.describe('Admin API CORS Support', () => {
   test('OPTIONS /api/admin/courses - should handle preflight request', async ({
     request,
   }) => {
-    const response = await request.fetch(`${baseURL}/api/admin/courses`, {
+    const response = await request.fetch('/api/admin/courses', {
       method: 'OPTIONS',
     });
 
@@ -108,7 +106,7 @@ test.describe('Admin API CORS Support', () => {
   test('OPTIONS /api/admin/analytics - should handle preflight request', async ({
     request,
   }) => {
-    const response = await request.fetch(`${baseURL}/api/admin/analytics`, {
+    const response = await request.fetch('/api/admin/analytics', {
       method: 'OPTIONS',
     });
 
@@ -125,7 +123,7 @@ test.describe('Admin API CORS Support', () => {
   test('OPTIONS /api/admin/errors - should handle preflight request', async ({
     request,
   }) => {
-    const response = await request.fetch(`${baseURL}/api/admin/errors`, {
+    const response = await request.fetch('/api/admin/errors', {
       method: 'OPTIONS',
     });
 
@@ -142,7 +140,7 @@ test.describe('Admin API CORS Support', () => {
   test('GET /api/admin/users - should include CORS headers in response', async ({
     request,
   }) => {
-    const response = await request.get(`${baseURL}/api/admin/users`);
+    const response = await request.get('/api/admin/users');
 
     // Should include CORS headers even on error responses
     const headers = response.headers();
@@ -152,7 +150,7 @@ test.describe('Admin API CORS Support', () => {
 
 test.describe('Admin API Response Format', () => {
   test('Error responses should include requestId', async ({ request }) => {
-    const response = await request.get(`${baseURL}/api/admin/users`);
+    const response = await request.get('/api/admin/users');
 
     const body = await response.json();
     expect(body.meta).toBeDefined();
@@ -164,7 +162,7 @@ test.describe('Admin API Response Format', () => {
     request,
   }) => {
     // Use an endpoint that requires authentication to test error response format
-    const response = await request.get(`${baseURL}/api/admin/users`);
+    const response = await request.get('/api/admin/users');
 
     const body = await response.json();
     expect(body).toHaveProperty('success');

--- a/tests/e2e/courses-empty-state.spec.ts
+++ b/tests/e2e/courses-empty-state.spec.ts
@@ -1,15 +1,15 @@
 import { expect, test } from '@playwright/test';
 import { gotoStable } from './helpers/nav';
 
-const isExternalBase = !!process.env.PLAYWRIGHT_BASE_URL;
-
 test.describe('Courses empty state', () => {
   test.beforeAll(async ({ request }) => {
-    try {
-      await request.get('http://localhost:3000/', { timeout: 3000 });
-      await request.get('http://localhost:3000/courses', { timeout: 3000 });
-    } catch {
-      // best-effort
+    // Warm cache/buffer regardless of deployment base URL
+    for (const path of ['/', '/courses']) {
+      try {
+        await request.get(path, { timeout: 3000 });
+      } catch {
+        // best-effort only for environments where the route is available
+      }
     }
   });
 


### PR DESCRIPTION
### **User description**
## Summary
- ensure admin API Playwright tests respect configured base URL
- make empty-state warmup relative,
- add academy-specific JSON-LD schema and metadata

## Testing
- npm run build
- npx playwright test tests/e2e/admin-api.spec.ts
- npx playwright test tests/e2e/courses-empty-state.spec.ts tests/e2e/seo-academy.spec.ts


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix admin API E2E tests to respect configured base URL

- Add academy-specific JSON-LD schema and metadata

- Make empty-state warmup relative to deployment base URL

- Pass production base URL to E2E tests in CI/CD


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["E2E Tests"] -->|"Use relative URLs"| B["Playwright Base URL"]
  C["Academy Page"] -->|"Use academyPage schema"| D["JSON-LD Metadata"]
  E["CI/CD Workflow"] -->|"Pass NEXT_PUBLIC_APP_URL"| F["Production Tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schemas.ts</strong><dd><code>Add academy-specific JSON-LD schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/seo/schemas.ts

<ul><li>Added new <code>academyPage</code> schema combination with organization, webpage, <br>and breadcrumb schemas<br> <li> Configured academy-specific metadata including German title and <br>description<br> <li> Included academy URL in breadcrumb navigation structure</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/25/files#diff-bfded6ed22c3ce7d4d513f8d57ca82cb683d114ee17664927e3c65ba821c775d">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin-api.spec.ts</strong><dd><code>Use relative URLs in admin API tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/e2e/admin-api.spec.ts

<ul><li>Removed hardcoded <code>baseURL</code> variable construction<br> <li> Changed all API endpoint calls to use relative URLs instead of <br>absolute URLs<br> <li> Allows tests to respect Playwright's configured base URL from <br>environment</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/25/files#diff-4f80654c64b24d8de19419e29ad9e295da837f7a440ad5c15bdbc62aacd5a187">+11/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>courses-empty-state.spec.ts</strong><dd><code>Make warmup relative to deployment base URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/e2e/courses-empty-state.spec.ts

<ul><li>Removed <code>isExternalBase</code> variable that checked for external base URL<br> <li> Changed warmup logic to use relative paths instead of hardcoded <br>localhost<br> <li> Made cache warming work with any deployment base URL via Playwright <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/25/files#diff-40616eb0824488dd017c4c8fcff5c9932ba645404d55dc1e2c288039b54e878e">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Use academy-specific schema for page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/academy/page.tsx

<ul><li>Changed JSON-LD schema from <code>aboutPage</code> to <code>academyPage</code><br> <li> Ensures academy page uses correct academy-specific metadata instead of <br>generic about page schema</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/25/files#diff-cea7ae363e39c3b2817a4cbf607a3fe2141a329a1ff2833e12e3c24e4017453d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Pass production URL to E2E tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Added <code>NEXT_PUBLIC_APP_URL</code> environment variable to E2E test job<br> <li> Passes production alias URL to tests for proper base URL configuration<br> <li> Ensures E2E tests run against correct production endpoint</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/25/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

