### PR TITLE
Update deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -320,6 +320,40 @@ jobs:
           echo "Deployment candidate URL: $url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
+      - name: Assign Production Alias
+        if: ${{ steps.deploy.outputs.url != '' }}
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          deployment="$DEPLOY_URL"
+          if [[ -z "$deployment" ]]; then
+            echo "No deployment URL available for alias assignment." >&2
+            exit 1
+          fi
+
+          # Ensure deployment value includes scheme for the CLI
+          if [[ ! "$deployment" =~ ^https?:// ]]; then
+            deployment="https://$deployment"
+          fi
+
+          # Derive bare domain from configured production alias (strip scheme and path)
+          alias_domain="${PRODUCTION_ALIAS#https://}"
+          alias_domain="${alias_domain#http://}"
+          alias_domain="${alias_domain%%/*}"
+
+          if [[ -z "$alias_domain" ]]; then
+            echo "Unable to derive alias domain from PRODUCTION_ALIAS=$PRODUCTION_ALIAS" >&2
+            exit 1
+          fi
+
+          echo "Assigning alias ${alias_domain} to deployment ${deployment}" | tee -a "$GITHUB_STEP_SUMMARY"
+          vercel alias set "$deployment" "$alias_domain" --token="$SANITIZED_VERCEL_TOKEN" --scope="$VERCEL_ORG_ID" >/tmp/vercel-alias.log
+          echo "Vercel alias response:" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/vercel-alias.log | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Poll Deployment Readiness (health check)
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
### **User description**
Updated the GitHub Actions deploy workflow with latest changes.


___

### **PR Type**
Enhancement


___

### **Description**
- Add production alias assignment step to deploy workflow

- Validates deployment URL and derives bare domain from alias

- Executes Vercel CLI command to assign alias to deployment

- Logs alias assignment results to GitHub step summary


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Deploy Step"] -->|"outputs deployment URL"| B["Assign Production Alias"]
  B -->|"validates URL"| C["Derive Alias Domain"]
  C -->|"executes vercel alias set"| D["Log Results"]
  D -->|"continues to"| E["Poll Deployment Readiness"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Add production alias assignment step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Added new "Assign Production Alias" workflow step after deployment<br> <li> Validates deployment URL is available and properly formatted<br> <li> Extracts bare domain from PRODUCTION_ALIAS environment variable<br> <li> Executes <code>vercel alias set</code> command with deployment URL and alias domain<br> <li> Logs Vercel CLI response to GitHub step summary for visibility</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/26/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

