### PR TITLE
ci(deploy): assign Vercel production alias after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -320,6 +320,40 @@ jobs:
           echo "Deployment candidate URL: $url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
+      - name: Assign Production Alias
+        if: ${{ steps.deploy.outputs.url != '' }}
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          deployment="$DEPLOY_URL"
+          if [[ -z "$deployment" ]]; then
+            echo "No deployment URL available for alias assignment." >&2
+            exit 1
+          fi
+
+          # Ensure deployment value includes scheme for the CLI
+          if [[ ! "$deployment" =~ ^https?:// ]]; then
+            deployment="https://$deployment"
+          fi
+
+          # Derive bare domain from configured production alias (strip scheme and path)
+          alias_domain="${PRODUCTION_ALIAS#https://}"
+          alias_domain="${alias_domain#http://}"
+          alias_domain="${alias_domain%%/*}"
+
+          if [[ -z "$alias_domain" ]]; then
+            echo "Unable to derive alias domain from PRODUCTION_ALIAS=$PRODUCTION_ALIAS" >&2
+            exit 1
+          fi
+
+          echo "Assigning alias ${alias_domain} to deployment ${deployment}" | tee -a "$GITHUB_STEP_SUMMARY"
+          vercel alias set "$deployment" "$alias_domain" --token="$SANITIZED_VERCEL_TOKEN" --scope="$VERCEL_ORG_ID" >/tmp/vercel-alias.log
+          echo "Vercel alias response:" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/vercel-alias.log | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Poll Deployment Readiness (health check)
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
This PR updates the production deploy workflow to explicitly assign the Vercel production alias to the newly created deployment after a successful deploy.

Why
- Prevent E2E and users from hitting a stale alias that still points to an older deployment
- Aligns live alias (hemera-tau.vercel.app) with the latest deployment URL discovered in the job

What changed
- Add "Assign Production Alias" step that runs `vercel alias set <deployment> <alias>` using the discovered `steps.deploy.outputs.url`
- Keep artifact/upload and health checks intact
- Use stable actions versions (checkout/setup-node/upload-artifact/github-script v4/v7) for compatibility

Safety
- Only runs when a deployment URL is available
- Derives bare alias domain from env `PRODUCTION_ALIAS`
- Logs response into step summary for traceability

Follow-ups
- If the deploy job only discovers the alias URL (rare, protected deployments), we may add a guard to skip alias assignment to avoid a CLI error (tracked in a later patch if observed).

Once merged, the alias should point to the latest prod deployment and the admin/users envelope should match tests.
