### PR TITLE
chore(warnings): widen Node engine to >=22 <25 and update husky prepare for v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "lint:ci": "eslint --cache --max-warnings=0 --ext .ts,.tsx,.js,.jsx .",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "jest",
     "test:unit": "jest tests/unit",
     "test:contracts": "jest tests/contracts",
@@ -86,7 +86,7 @@
     "dotenv-cli": "^11.0.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.33",
-    "husky": "^8.0.0",
+    "husky": "^9.0.0",
     "jest": "^30.2.0",
     "jest-junit": "^16.0.0",
     "lint-staged": "^16.2.3",
@@ -100,7 +100,7 @@
     "webpack": "^5.102.1"
   },
   "engines": {
-    "node": "22.x"
+    "node": ">=22 <25"
   },
   "prisma": {
     "seed": "node --loader ts-node/esm prisma/seed.ts"


### PR DESCRIPTION
This PR addresses install-time warnings:

Changes
- engines.node: widen to ">=22 <25" to stop EBADENGINE on Node v24
- scripts.prepare: switch from `husky install` to `husky` (v9) to remove deprecation warning
- keep eslint-config-next at 14.2.33 to avoid unintended lint rule changes

Verification
- npm install: no EBADENGINE warning; husky deprecation removed
- No vulnerabilities reported

Notes
- Remaining deprecation notices (e.g., inflight, glob, @humanwhocodes/*, eslint@8) are transitive. Fully eliminating them would require larger upgrades (ESLint 9 + flat config, possible webpack and other tooling bumps). I can prepare a follow-up migration plan/PR if desired.
