### PR TITLE
fix(deploy): Run vercel deploy in background to avoid 'Completing...' stall

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -266,53 +266,67 @@ jobs:
         run: |
           set -euo pipefail
           echo "Starting Vercel production deploy (prebuilt)…"
-          # Try to deploy with a bounded timeout to avoid long blocking waits
-          # If the CLI prints the URL, capture it; otherwise, fallback to API to discover latest prod deployment
+
+          # Start the deploy in background - the CLI hangs on "Completing..." for minutes
+          # We'll poll the API instead to get the deployment URL
+          vercel deploy --prebuilt --prod --token="$SANITIZED_VERCEL_TOKEN" --scope="$VERCEL_ORG_ID" --yes > deploy.out 2>&1 &
+          deploy_pid=$!
+
+          # Give Vercel CLI a moment to initiate the deployment
+          sleep 10
+
+          # Try to extract URL from CLI output (may have printed it already)
           url=""
-          if timeout 15m bash -c 'vercel deploy --prebuilt --prod --token="$SANITIZED_VERCEL_TOKEN" --scope="$VERCEL_ORG_ID" --yes | tee deploy.out'; then
-            # Try to extract a https URL from CLI output (prefer custom domain, then *.vercel.app)
-            if grep -Eo 'https?://[a-zA-Z0-9._-]+' deploy.out | head -n1 >/dev/null; then
-              url=$(grep -Eo 'https?://[a-zA-Z0-9._-]+' deploy.out | head -n1)
+          if [[ -f deploy.out ]]; then
+            cat deploy.out
+            if grep -Eo 'https://[a-zA-Z0-9._-]+\.vercel\.app' deploy.out | head -n1 >/dev/null 2>&1; then
+              url=$(grep -Eo 'https://[a-zA-Z0-9._-]+\.vercel\.app' deploy.out | head -n1)
+              echo "Found URL in CLI output: $url"
             fi
-          else
-            echo "vercel deploy timed out after 15m; will try to discover deployment via API…" >&2
           fi
 
+          # Poll for deployment via API (more reliable than waiting for CLI)
           if [[ -z "${url}" ]]; then
-            echo "Attempting to fetch latest production deployment via Vercel API v13…"
-            api_resp=$(curl -fsSL -H "Authorization: Bearer $SANITIZED_VERCEL_TOKEN" \
-              "https://api.vercel.com/v13/deployments?projectId=${VERCEL_PROJECT_ID}&target=production&limit=1") || true
-            if [[ -n "${api_resp:-}" ]]; then
-              deploy_url=$(echo "$api_resp" | jq -r '.deployments[0].url // empty' 2>/dev/null || true)
-              if [[ -n "${deploy_url:-}" ]]; then
-                # API returns host without scheme sometimes
-                if [[ "$deploy_url" =~ ^https?:// ]]; then
-                  url="$deploy_url"
-                else
-                  url="https://$deploy_url"
+            echo "Polling Vercel API for latest deployment..."
+            for i in {1..30}; do
+              api_resp=$(curl -fsSL -H "Authorization: Bearer $SANITIZED_VERCEL_TOKEN" \
+                "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&target=production&limit=1&teamId=${VERCEL_ORG_ID}" 2>/dev/null) || true
+              if [[ -n "${api_resp:-}" ]]; then
+                deploy_url=$(echo "$api_resp" | jq -r '.deployments[0].url // empty' 2>/dev/null || true)
+                deploy_state=$(echo "$api_resp" | jq -r '.deployments[0].state // empty' 2>/dev/null || true)
+                deploy_created=$(echo "$api_resp" | jq -r '.deployments[0].created // empty' 2>/dev/null || true)
+                
+                echo "Poll $i: state=$deploy_state, url=$deploy_url, created=$deploy_created"
+                
+                # Check if this is a recent deployment (within last 5 minutes)
+                if [[ -n "${deploy_url:-}" && -n "${deploy_created:-}" ]]; then
+                  now=$(date +%s)
+                  created_ts=$((deploy_created / 1000))
+                  age=$((now - created_ts))
+                  
+                  if [[ $age -lt 300 ]]; then
+                    if [[ "$deploy_url" =~ ^https?:// ]]; then
+                      url="$deploy_url"
+                    else
+                      url="https://$deploy_url"
+                    fi
+                    echo "Found recent deployment: $url (age: ${age}s)"
+                    break
+                  fi
                 fi
               fi
-            fi
+              sleep 5
+            done
           fi
 
-          if [[ -z "${url}" ]]; then
-            echo "Attempting to fetch latest production deployment via Vercel API v6…"
-            api_resp_v6=$(curl -fsSL -H "Authorization: Bearer $SANITIZED_VERCEL_TOKEN" \
-              "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&target=production&limit=1&teamId=${VERCEL_ORG_ID}") || true
-            if [[ -n "${api_resp_v6:-}" ]]; then
-              deploy_url=$(echo "$api_resp_v6" | jq -r '.deployments[0].url // empty' 2>/dev/null || true)
-              if [[ -n "${deploy_url:-}" ]]; then
-                if [[ "$deploy_url" =~ ^https?:// ]]; then
-                  url="$deploy_url"
-                else
-                  url="https://$deploy_url"
-                fi
-              fi
-            fi
+          # Kill the background deploy process - we don't need to wait for "Completing..."
+          if kill -0 $deploy_pid 2>/dev/null; then
+            echo "Terminating background deploy process (we have the URL)"
+            kill $deploy_pid 2>/dev/null || true
           fi
 
+          # Final fallback to production alias
           if [[ -z "${url}" ]]; then
-            # As a final fallback, assume the known production alias (kept in sync with E2E job)
             url="${PRODUCTION_ALIAS}"
             echo "Falling back to known production alias: $url"
           fi


### PR DESCRIPTION
### **User description**
## Problem

Der Vercel CLI Befehl `vercel deploy --prebuilt --prod` bleibt bei der "Completing..." Phase hängen und wartet auf DNS/CDN Propagation. Das kann 10+ Minuten dauern und führt zu Workflow-Abbrüchen durch Concurrency-Cancellation.

**Betroffene Runs:**
- https://github.com/Laparo/hemera/actions/runs/19978112644 (abgebrochen nach ~10 Min bei Completing)
- https://github.com/Laparo/hemera/actions/runs/19978394124 (abgebrochen nach ~6 Min bei Completing)

## Lösung

- Starte `vercel deploy` im Hintergrund statt blockierend zu warten
- Polle die Vercel API um die Deployment-URL zu erhalten (zuverlässiger)
- Beende den Hintergrundprozess sobald die URL verfügbar ist
- Reduziert den Deploy-Step von 10+ Minuten auf ~30 Sekunden

## Änderungen

- Background-Ausführung des Deploy-Befehls
- API-Polling mit Alters-Check (nur Deployments der letzten 5 Minuten)
- Sauberes Beenden des Hintergrundprozesses

## Testing

Der nächste Deploy-Workflow nach dem Merge wird das neue Verhalten testen.


___

### **PR Type**
Bug fix


___

### **Description**
- Run Vercel deploy in background to avoid indefinite "Completing..." stall

- Poll Vercel API for deployment URL instead of waiting for CLI completion

- Kill background process once URL is obtained, reducing deploy time from 10+ minutes to ~30 seconds

- Add deployment age check to ensure only recent deployments are matched


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Start vercel deploy<br/>in background"] --> B["Sleep 10s<br/>for initiation"]
  B --> C["Extract URL from<br/>CLI output"]
  C --> D{URL found?}
  D -->|No| E["Poll Vercel API<br/>up to 30 times"]
  E --> F["Check deployment<br/>age < 5 min"]
  F --> G{Recent deployment?}
  G -->|Yes| H["Extract URL"]
  G -->|No| I["Continue polling"]
  I --> E
  D -->|Yes| J["Kill background<br/>process"]
  H --> J
  J --> K["Return deployment URL"]
  K --> L{URL available?}
  L -->|No| M["Fallback to<br/>production alias"]
  L -->|Yes| M
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Refactor deploy to background polling with age validation</code></dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Changed Vercel deploy execution from blocking with 15-minute timeout <br>to background process<br> <li> Replaced sequential API fallbacks (v13 then v6) with single polling <br>loop (up to 30 attempts with 5-second intervals)<br> <li> Added deployment age validation to only match deployments created <br>within last 5 minutes<br> <li> Implemented background process termination once deployment URL is <br>obtained<br> <li> Simplified URL extraction logic to specifically match <code>.vercel.app</code> <br>domains</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/207/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+49/-35</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

