### PR TITLE
fix(deploy): Wait for deployment ready state before assigning alias

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -334,6 +334,49 @@ jobs:
           echo "Deployment candidate URL: $url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
+      - name: Wait for Deployment Ready
+        if: ${{ steps.deploy.outputs.url != '' }}
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          deployment="$DEPLOY_URL"
+          # Extract deployment ID from URL (e.g., hemera-mozu6lfov-laparo-team.vercel.app -> hemera-mozu6lfov)
+          deploy_host="${deployment#https://}"
+          deploy_host="${deploy_host#http://}"
+
+          echo "Waiting for deployment to be ready: $deployment"
+
+          for i in {1..60}; do
+            # Check deployment state via API
+            api_resp=$(curl -fsSL -H "Authorization: Bearer $SANITIZED_VERCEL_TOKEN" \
+              "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&limit=5&teamId=${VERCEL_ORG_ID}" 2>/dev/null) || true
+            
+            if [[ -n "${api_resp:-}" ]]; then
+              # Find our deployment by URL
+              deploy_state=$(echo "$api_resp" | jq -r --arg host "$deploy_host" '.deployments[] | select(.url == $host) | .readyState // .state' 2>/dev/null | head -n1) || true
+              
+              echo "Poll $i: deployment state = $deploy_state"
+              
+              if [[ "$deploy_state" == "READY" ]]; then
+                echo "✅ Deployment is ready!"
+                break
+              elif [[ "$deploy_state" == "ERROR" || "$deploy_state" == "CANCELED" ]]; then
+                echo "❌ Deployment failed with state: $deploy_state"
+                exit 1
+              fi
+            fi
+            
+            if [[ $i -ge 60 ]]; then
+              echo "⚠️ Timeout waiting for deployment - proceeding anyway"
+              break
+            fi
+            
+            sleep 5
+          done
+
       - name: Assign Production Alias
         if: ${{ steps.deploy.outputs.url != '' }}
         env:


### PR DESCRIPTION
### **User description**
## Problem

Der vorherige Fix (#207) startet das Deployment im Hintergrund und bekommt die URL schnell über die API. Allerdings ist das Deployment zu diesem Zeitpunkt noch nicht im "READY" Status, was zum Fehler führt:

```
Error: The deployment https://hemera-mozu6lfov-laparo-team.vercel.app is not ready.
```

## Lösung

Fügt einen neuen Step "Wait for Deployment Ready" hinzu, der:
- Die Vercel API pollt um den Deployment-Status zu prüfen
- Wartet bis der Status "READY" ist (max. 5 Minuten)
- Bei ERROR oder CANCELED abbricht
- Erst danach den Alias zuweist

## Änderungen

- Neuer Step: "Wait for Deployment Ready"
- Pollt alle 5 Sekunden für bis zu 60 Iterationen (5 Min)
- Prüft `readyState` oder `state` Feld im API Response


___

### **PR Type**
Bug fix


___

### **Description**
- Add polling step to wait for deployment ready state before alias assignment

- Polls Vercel API every 5 seconds for up to 5 minutes

- Extracts deployment ID from URL and checks readyState field

- Fails fast on ERROR or CANCELED states, proceeds on timeout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Deploy Step"] -->|Get URL| B["Wait for Deployment Ready"]
  B -->|Poll API| C{Check State}
  C -->|READY| D["Assign Production Alias"]
  C -->|ERROR/CANCELED| E["Fail"]
  C -->|Timeout| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Add deployment ready state polling step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Add new "Wait for Deployment Ready" step after deployment<br> <li> Poll Vercel API every 5 seconds for up to 60 iterations (5 minutes)<br> <li> Extract deployment host from URL and query API for readyState<br> <li> Exit with error on ERROR or CANCELED states, proceed on READY or <br>timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/208/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

