### PR TITLE
fix(deploy): Also assign alias to hemera.academy custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -411,6 +411,19 @@ jobs:
           echo "Vercel alias response:" >> "$GITHUB_STEP_SUMMARY"
           cat /tmp/vercel-alias.log | tee -a "$GITHUB_STEP_SUMMARY"
 
+          # Also assign custom domain aliases
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Assigning custom domain aliases..." | tee -a "$GITHUB_STEP_SUMMARY"
+
+          for custom_domain in "hemera.academy" "www.hemera.academy"; do
+            echo "Assigning alias ${custom_domain} to deployment ${deployment}" | tee -a "$GITHUB_STEP_SUMMARY"
+            if vercel alias set "$deployment" "$custom_domain" --token="$SANITIZED_VERCEL_TOKEN" --scope="$VERCEL_ORG_ID" 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"; then
+              echo "✅ Alias ${custom_domain} assigned successfully" | tee -a "$GITHUB_STEP_SUMMARY"
+            else
+              echo "⚠️ Failed to assign alias ${custom_domain} (may already be configured)" | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
       - name: Poll Deployment Readiness (health check)
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
### **User description**
## Problem

Das Deployment wird nur auf `hemera-tau.vercel.app` aliased, aber nicht auf die Custom Domain `hemera.academy`. Deshalb zeigt hemera.academy noch das alte Design.

## Lösung

Erweitert den "Assign Production Alias" Step um auch die Custom Domains zu setzen:
- `hemera.academy`
- `www.hemera.academy`

Der Befehl wird für jede Domain ausgeführt und fährt bei Fehlern fort (falls die Domain bereits im Vercel Dashboard konfiguriert ist).


___

### **PR Type**
Bug fix


___

### **Description**
- Assign production alias to custom domains hemera.academy and www.hemera.academy

- Add loop to set aliases for both custom domains in deployment workflow

- Continue on failure if domain already configured in Vercel dashboard


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Deploy to Vercel"] --> B["Assign alias to vercel.app domain"]
  B --> C["Assign aliases to custom domains"]
  C --> D["hemera.academy"]
  C --> E["www.hemera.academy"]
  D --> F["Continue on failure"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Add custom domain alias assignment to deployment workflow</code></dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Added loop to assign production aliases to custom domains <br><code>hemera.academy</code> and <code>www.hemera.academy</code><br> <li> Implemented error handling to continue on failure if domain already <br>configured<br> <li> Added logging and status indicators (✅/⚠️) for alias assignment <br>results</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/209/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

