### PR TITLE
fix(ci): Remove trailing spaces from deploy.yml to fix yamllint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -295,15 +295,15 @@ jobs:
                 deploy_url=$(echo "$api_resp" | jq -r '.deployments[0].url // empty' 2>/dev/null || true)
                 deploy_state=$(echo "$api_resp" | jq -r '.deployments[0].state // empty' 2>/dev/null || true)
                 deploy_created=$(echo "$api_resp" | jq -r '.deployments[0].created // empty' 2>/dev/null || true)
-                
+
                 echo "Poll $i: state=$deploy_state, url=$deploy_url, created=$deploy_created"
-                
+
                 # Check if this is a recent deployment (within last 5 minutes)
                 if [[ -n "${deploy_url:-}" && -n "${deploy_created:-}" ]]; then
                   now=$(date +%s)
                   created_ts=$((deploy_created / 1000))
                   age=$((now - created_ts))
-                  
+
                   if [[ $age -lt 300 ]]; then
                     if [[ "$deploy_url" =~ ^https?:// ]]; then
                       url="$deploy_url"
@@ -353,13 +353,13 @@ jobs:
             # Check deployment state via API
             api_resp=$(curl -fsSL -H "Authorization: Bearer $SANITIZED_VERCEL_TOKEN" \
               "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&limit=5&teamId=${VERCEL_ORG_ID}" 2>/dev/null) || true
-            
+
             if [[ -n "${api_resp:-}" ]]; then
               # Find our deployment by URL
               deploy_state=$(echo "$api_resp" | jq -r --arg host "$deploy_host" '.deployments[] | select(.url == $host) | .readyState // .state' 2>/dev/null | head -n1) || true
-              
+
               echo "Poll $i: deployment state = $deploy_state"
-              
+
               if [[ "$deploy_state" == "READY" ]]; then
                 echo "✅ Deployment is ready!"
                 break
@@ -368,12 +368,12 @@ jobs:
                 exit 1
               fi
             fi
-            
+
             if [[ $i -ge 60 ]]; then
               echo "⚠️ Timeout waiting for deployment - proceeding anyway"
               break
             fi
-            
+
             sleep 5
           done
 


### PR DESCRIPTION
### **User description**
## Problem
The `yaml-and-actions-lint.yml` workflow was failing on all PRs due to trailing spaces in `.github/workflows/deploy.yml`.

## Solution
Removed trailing spaces from the following lines in `deploy.yml`:
- Line 298
- Line 300
- Line 306
- Line 356
- Line 360
- Line 362
- Line 371
- Line 376

## Testing
- Ran `yamllint` locally to verify the fix
- This should unblock all pending PRs that are failing the yamllint check


___

### **PR Type**
Bug fix


___

### **Description**
- Remove trailing whitespace from deploy.yml workflow file

- Fix yamllint validation failures in CI pipeline

- Unblock pending PRs failing yaml-and-actions-lint check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["deploy.yml<br/>with trailing spaces"] -- "Remove whitespace" --> B["deploy.yml<br/>cleaned"]
  B -- "Pass yamllint" --> C["CI workflow<br/>succeeds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Remove trailing whitespace from workflow file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Removed trailing whitespace from 8 lines in deployment verification <br>scripts<br> <li> Lines affected: 298, 300, 306, 356, 360, 362, 371, 376<br> <li> Changes ensure yamllint compliance without functional code <br>modifications<br> <li> Fixes CI workflow validation failures</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/235/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

