### PR TITLE
fix(e2e): use SQLite adapter in prisma.ts for CI tests

### DIFF
--- a/lib/db/prisma.ts
+++ b/lib/db/prisma.ts
@@ -2,7 +2,14 @@ import { PrismaClient } from '@prisma/client';
 import { Pool } from 'pg';
 import { PrismaPg } from '@prisma/adapter-pg';
 
+// Check if DATABASE_URL is SQLite (file:// protocol)
+const isSqlite = process.env.DATABASE_URL?.startsWith('file:');
+
 function withSchemaParam(urlStr: string, schema?: string): string {
+  // SQLite URLs don't support schema params
+  if (urlStr.startsWith('file:')) {
+    return urlStr;
+  }
   try {
     const url = new URL(urlStr);
 
@@ -68,24 +75,46 @@ const connectionString = runtimeDbUrl ?? process.env.DATABASE_URL ?? '';
 const sslEnabled =
   process.env.PGSSL === '1' || process.env.PGSSL === 'true' ? true : undefined;
 
-// Create pool only if DATABASE_URL is available
-// During Next.js build, DATABASE_URL might not be set, so we use a fallback
-// that will fail gracefully at runtime if actual DB access is attempted
-const pool = new Pool({
-  connectionString:
-    connectionString || 'postgresql://localhost:5432/build_placeholder',
-  ssl: sslEnabled ? { rejectUnauthorized: true } : undefined,
-});
+// For SQLite (E2E tests), we use better-sqlite3 adapter
+// For PostgreSQL (production), we use pg adapter
+let prismaClient: PrismaClient;
+let closeDbFn: () => Promise<void>;
 
-const adapter = new PrismaPg(pool);
+if (isSqlite) {
+  // Dynamic import to avoid bundling sqlite3 in production
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { PrismaBetterSqlite3 } = require('@prisma/adapter-better-sqlite3');
+  const sqliteAdapter = new PrismaBetterSqlite3({
+    url: connectionString || 'file:./test.db',
+  });
+  prismaClient = new PrismaClient({ adapter: sqliteAdapter });
+  closeDbFn = async () => {
+    await prismaClient.$disconnect();
+  };
+} else {
+  // Create pool only if DATABASE_URL is available
+  // During Next.js build, DATABASE_URL might not be set, so we use a fallback
+  // that will fail gracefully at runtime if actual DB access is attempted
+  const pool = new Pool({
+    connectionString:
+      connectionString || 'postgresql://localhost:5432/build_placeholder',
+    ssl: sslEnabled ? { rejectUnauthorized: true } : undefined,
+  });
+
+  const adapter = new PrismaPg(pool);
+  prismaClient = new PrismaClient({ adapter });
+  closeDbFn = async () => {
+    await prismaClient.$disconnect();
+    await pool.end();
+  };
+}
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter });
+export const prisma = globalForPrisma.prisma ?? prismaClient;
 
 export async function closeDb(): Promise<void> {
-  await prisma.$disconnect();
-  await pool.end();
+  await closeDbFn();
 }
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
@@ -27,6 +27,6 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### **User description**
## Problem
E2E tests were failing in CI because `lib/db/prisma.ts` always used the PostgreSQL adapter (`PrismaPg`), even when `DATABASE_URL=file:./test.db` (SQLite) was configured.

This caused:
- Admin API tests returning 500 instead of 401
- CORS OPTIONS tests returning 400 instead of 200

## Solution
Modified `prisma.ts` to detect SQLite URLs (`file:` prefix) and use `PrismaBetterSqlite3` adapter:

- Added `isSqlite` detection based on `DATABASE_URL` prefix
- Conditional adapter selection (SQLite vs PostgreSQL)
- Updated `closeDb` function for both adapters

## Testing
- All 11 admin-api E2E tests pass locally
- Build succeeds
- TypeScript and ESLint checks pass

## Related
Fixes the pre-existing E2E test failures on main branch.


___

### **PR Type**
Bug fix


___

### **Description**
- Detect SQLite URLs and use PrismaBetterSqlite3 adapter for E2E tests

- Implement conditional adapter selection based on DATABASE_URL protocol

- Update closeDb function to handle both SQLite and PostgreSQL cleanup

- Skip schema parameter handling for SQLite URLs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DATABASE_URL"] -->|"startsWith file:"| B["Use PrismaBetterSqlite3"]
  A -->|"PostgreSQL URL"| C["Use PrismaPg with Pool"]
  B --> D["prismaClient"]
  C --> D
  D --> E["Export prisma instance"]
  B --> F["SQLite closeDb"]
  C --> G["PostgreSQL closeDb"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prisma.ts</strong><dd><code>Conditional Prisma adapter selection for SQLite and PostgreSQL</code></dd></summary>
<hr>

lib/db/prisma.ts

<ul><li>Added <code>isSqlite</code> detection based on <code>DATABASE_URL</code> prefix check<br> <li> Implemented conditional adapter selection between PrismaBetterSqlite3 <br>and PrismaPg<br> <li> Modified <code>withSchemaParam</code> to skip schema handling for SQLite URLs<br> <li> Updated <code>closeDb</code> function to handle cleanup for both adapters<br> <li> Used dynamic import for SQLite adapter to avoid production bundling</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/278/files#diff-5a356b98eee1977416f848d68c86fa2a3729acd2af36267169f4ecd996784eec">+42/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tsconfig.json</strong><dd><code>TypeScript configuration updates for Next.js</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tsconfig.json

<ul><li>Changed <code>jsx</code> compiler option from <code>preserve</code> to <code>react-jsx</code><br> <li> Added <code>.next/dev/types/**/*.ts</code> to include paths for type checking</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/278/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

