### PR TITLE
chore(deps): update @types/node to v25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@testcontainers/postgresql": "^11.9.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/jest": "^30.0.0",
-        "@types/node": "^24.10.1",
+        "@types/node": "^25.0.2",
         "@types/pg": "^8.11.6",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -4670,9 +4670,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
-      "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
+      "version": "25.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
+      "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -6387,7 +6387,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@testcontainers/postgresql": "^11.9.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/jest": "^30.0.0",
-    "@types/node": "^24.10.1",
+    "@types/node": "^25.0.2",
     "@types/pg": "^8.11.6",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -118,7 +118,7 @@
     "webpack": "^5.103.0"
   },
   "engines": {
-    "node": ">=22 <25"
+    "node": ">=22"
   },
   "prisma": {
     "seed": "node --loader ts-node/esm prisma/seed.ts"


### PR DESCRIPTION
### **User description**
## Summary
Updates `@types/node` from 24.10.4 to 25.0.2 for Node.js 25 compatibility.

## Changes
- Updated `@types/node` from 24.10.4 to 25.0.2
- Relaxed Node.js engine requirement from `>=22 <25` to `>=22`

## Testing
- ✅ Build successful
- ✅ TypeScript check passed
- ✅ CI will validate all tests


___

### **PR Type**
Enhancement


___

### **Description**
- Update @types/node from 24.10.1 to 25.0.2

- Relax Node.js engine requirement to support v25.x

- Enable compatibility with Node.js 25 releases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["@types/node v24.10.1"] -- "upgrade to" --> B["@types/node v25.0.2"]
  C["Node.js engine: >=22 <25"] -- "relax to" --> D["Node.js engine: >=22"]
  B --> E["Node.js 25.x compatibility"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update @types/node and relax engine constraint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Updated @types/node dependency from ^24.10.1 to ^25.0.2<br> <li> Relaxed Node.js engine requirement from >=22 <25 to >=22<br> <li> Enables support for Node.js 25.x versions</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/279/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

