### PR TITLE
fix: use lint-staged --no-stash to prevent git index corruption

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx --no-install lint-staged
+npx --no-install lint-staged --no-stash


### PR DESCRIPTION
### **User description**
## Problem

Der lint-staged Stash-Mechanismus konfligiert mit VS Code File Watchers, was dazu führt, dass der Git-Index als korrupt erscheint (alle Dateien als gelöscht angezeigt).

## Lösung

Füge `--no-stash` Flag zu lint-staged hinzu, um den Stash-Mechanismus zu deaktivieren.

## Trade-off

Mit `--no-stash` werden unstaged Änderungen nicht temporär gespeichert. Das bedeutet:
- ✅ Kein Index-Korruptions-Problem mehr
- ⚠️ Unstaged Änderungen werden auch vom Linter/Formatter verarbeitet

## Rollbar

Kein Einfluss auf Monitoring.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `--no-stash` flag to lint-staged in pre-commit hook

- Prevents git index corruption caused by stash conflicts

- Resolves VS Code file watcher compatibility issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["lint-staged hook"] -->|without --no-stash| B["Stash conflicts with VS Code watchers"]
  B --> C["Git index appears corrupted"]
  A -->|with --no-stash| D["No stash mechanism"]
  D --> E["Index integrity preserved"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pre-commit</strong><dd><code>Add --no-stash flag to lint-staged command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.husky/pre-commit

<ul><li>Add <code>--no-stash</code> flag to lint-staged command<br> <li> Disables stash mechanism to prevent git index corruption<br> <li> Resolves conflicts with VS Code file watchers</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/294/files#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

