### PR TITLE
chore: remove deprecated @types/uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "@types/pg": "^8.11.6",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
-        "@types/uuid": "^10.0.0",
         "better-sqlite3": "^12.5.0",
         "cspell": "^9.4.0",
         "dotenv": "^17.2.3",
@@ -4637,13 +4636,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -15907,7 +15899,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@types/pg": "^8.11.6",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
-    "@types/uuid": "^10.0.0",
     "better-sqlite3": "^12.5.0",
     "cspell": "^9.4.0",
     "dotenv": "^17.2.3",


### PR DESCRIPTION
### **User description**
## Summary
Removes the deprecated `@types/uuid` package since `uuid` now provides its own TypeScript definitions.

This also closes #296 (Dependabot PR) which failed due to Dependabot's inability to access repository secrets for Vercel deployments.

## Changes
- Removed `@types/uuid` from devDependencies

## Testing
- ✅ Build passes
- ✅ TypeScript compilation passes


___

### **PR Type**
Enhancement


___

### **Description**
- Remove deprecated `@types/uuid` package from devDependencies

- UUID library now provides native TypeScript definitions

- Simplifies dependency management and reduces package bloat


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["package.json"] -- "remove @types/uuid" --> B["Cleaner dependencies"]
  B -- "uuid provides own types" --> C["Native TypeScript support"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Remove deprecated @types/uuid dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Removed <code>@types/uuid</code> from devDependencies section<br> <li> UUID package now provides its own TypeScript type definitions<br> <li> Reduces unnecessary type definition packages</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/297/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

