### PR TITLE
ci: skip deploy preview for Dependabot PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,8 +152,8 @@ jobs:
     name: Deploy Preview
     runs-on: ubuntu-latest
     needs: quality-gates
-    # Run on PRs, or manual dispatch explicitly targeting preview on any ref
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.environment == 'preview')
+    # Run on PRs (except Dependabot - no access to secrets), or manual dispatch explicitly targeting preview on any ref
+    if: (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') || (github.event_name == 'workflow_dispatch' && inputs.environment == 'preview')
     permissions:
       contents: read
       pull-requests: write

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "biome check --write",
       "cspell --config ./cspell.config.yaml --no-progress --no-summary --no-must-find-files --exclude 'lib/generated/**'"
     ],
-    "*.{json,yaml,yml}": [
+    "*.json": [
       "biome format --write"
     ],
     "*.{md,mdx}": [


### PR DESCRIPTION
### **User description**
## Summary
Fixes Dependabot PR failures (like #295, #296) by skipping the deploy-preview job for Dependabot PRs.

## Problem
Dependabot PRs cannot access repository secrets (VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID), causing the `Deploy Preview` job to fail with:
```
Error: No existing credentials found. Please run `vercel login` or pass "--token"
```

## Solution
- Added `github.actor != 'dependabot[bot]'` check to the deploy-preview job condition
- Fixed lint-staged config: removed yaml/yml from biome format (biome doesn't support YAML)

## Testing
- Quality Gates still run for Dependabot PRs (they have access to public actions)
- Regular PRs continue to get preview deployments


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Skip deploy preview job for Dependabot PRs lacking secret access

- Prevent Vercel token authentication failures in Dependabot workflows

- Remove unsupported YAML formatting from lint-staged biome config


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot PR"] -->|github.actor check| B["Deploy Preview Job"]
  B -->|dependabot[bot]| C["Skip Job"]
  B -->|regular user| D["Run Deployment"]
  E["lint-staged config"] -->|remove yaml/yml| F["biome format only json"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Add Dependabot actor check to deploy preview job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Added <code>github.actor != 'dependabot[bot]'</code> condition to deploy-preview <br>job<br> <li> Prevents Dependabot PRs from attempting deployment without secret <br>access<br> <li> Allows manual workflow dispatch to still trigger preview deployments<br> <li> Updated job condition comment to clarify Dependabot exclusion</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/298/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Remove unsupported YAML from biome lint-staged config</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Removed <code>yaml</code> and <code>yml</code> file extensions from lint-staged biome format <br>rule<br> <li> Biome does not support YAML formatting, preventing lint errors<br> <li> Keeps JSON formatting in biome while excluding unsupported formats</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/298/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

