### PR TITLE
fix: add safe Clerk component wrappers for bypass mode

### DIFF
--- a/components/auth/ClerkComponents.tsx
+++ b/components/auth/ClerkComponents.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import {
+  ClerkLoaded,
+  ClerkLoading,
+  SignedIn as ClerkSignedIn,
+  SignedOut as ClerkSignedOut,
+  UserButton as ClerkUserButton,
+} from '@clerk/nextjs';
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+
+interface AuthWrapperProps {
+  children: ReactNode;
+}
+
+/**
+ * Safe wrapper for SignedIn that handles missing ClerkProvider
+ * When Clerk is bypassed, this renders nothing (user is treated as signed out)
+ */
+export function SignedIn({ children }: AuthWrapperProps) {
+  const [isClerkAvailable, setIsClerkAvailable] = useState<boolean | null>(
+    null
+  );
+
+  useEffect(() => {
+    // Check if ClerkProvider context is available by looking for Clerk on window
+    const clerkAvailable =
+      typeof window !== 'undefined' &&
+      // biome-ignore lint/suspicious/noExplicitAny: Clerk attaches to window
+      (window as any).__clerk_publishable_key !== undefined;
+    setIsClerkAvailable(clerkAvailable);
+  }, []);
+
+  // Still loading/checking
+  if (isClerkAvailable === null) {
+    return null;
+  }
+
+  // Clerk is bypassed, treat user as signed out
+  if (!isClerkAvailable) {
+    return null;
+  }
+
+  return <ClerkSignedIn>{children}</ClerkSignedIn>;
+}
+
+/**
+ * Safe wrapper for SignedOut that handles missing ClerkProvider
+ * When Clerk is bypassed, this renders children (user is treated as signed out)
+ */
+export function SignedOut({ children }: AuthWrapperProps) {
+  const [isClerkAvailable, setIsClerkAvailable] = useState<boolean | null>(
+    null
+  );
+
+  useEffect(() => {
+    // Check if ClerkProvider context is available
+    const clerkAvailable =
+      typeof window !== 'undefined' &&
+      // biome-ignore lint/suspicious/noExplicitAny: Clerk attaches to window
+      (window as any).__clerk_publishable_key !== undefined;
+    setIsClerkAvailable(clerkAvailable);
+  }, []);
+
+  // Still loading/checking - show nothing to prevent flash
+  if (isClerkAvailable === null) {
+    return null;
+  }
+
+  // Clerk is bypassed, show signed-out content
+  if (!isClerkAvailable) {
+    return <>{children}</>;
+  }
+
+  return <ClerkSignedOut>{children}</ClerkSignedOut>;
+}
+
+/**
+ * Safe wrapper for UserButton that handles missing ClerkProvider
+ * When Clerk is bypassed, this renders nothing
+ */
+export function UserButton(
+  props: React.ComponentProps<typeof ClerkUserButton>
+) {
+  const [isClerkAvailable, setIsClerkAvailable] = useState<boolean | null>(
+    null
+  );
+
+  useEffect(() => {
+    const clerkAvailable =
+      typeof window !== 'undefined' &&
+      // biome-ignore lint/suspicious/noExplicitAny: Clerk attaches to window
+      (window as any).__clerk_publishable_key !== undefined;
+    setIsClerkAvailable(clerkAvailable);
+  }, []);
+
+  if (isClerkAvailable === null || !isClerkAvailable) {
+    return null;
+  }
+
+  return <ClerkUserButton {...props} />;
+}

--- a/components/navigation/PublicNavigation.tsx
+++ b/components/navigation/PublicNavigation.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
 import {
   AppBar,
   Box,
@@ -12,6 +11,7 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { useLayoutEffect, useState } from 'react';
+import { SignedIn, SignedOut, UserButton } from '../auth/ClerkComponents';
 import ClientOnly from '../ClientOnly';
 
 // Hemera Design Tokens


### PR DESCRIPTION
### **User description**
## Summary
Fixes Rollbar error #54 that occurs when Clerk components are used outside ClerkProvider.

## Problem
When Clerk is bypassed (on Vercel deployment URLs), the `SignedIn`, `SignedOut`, and `UserButton` components from `@clerk/nextjs` throw an error:
```
Error: @clerk/nextjs: SignedOut can only be used within the <ClerkProvider /> component.
```

## Solution
Created safe wrapper components in `components/auth/ClerkComponents.tsx`:
- `SignedIn` - Renders children only when Clerk is available AND user is signed in
- `SignedOut` - Renders children when Clerk is bypassed OR user is signed out  
- `UserButton` - Renders only when Clerk is available

These wrappers detect Clerk availability via `window.__clerk_publishable_key` and provide graceful fallbacks.

## Changes
- Added `components/auth/ClerkComponents.tsx` with safe wrappers
- Updated `PublicNavigation.tsx` to use safe wrappers instead of direct Clerk imports

## Testing
- ✅ Build passes
- ✅ TypeScript compilation passes
- Users on Vercel preview URLs will see sign-in/sign-up buttons (signed-out state)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Created safe Clerk component wrappers to handle bypass mode gracefully

- Detects Clerk availability via `window.__clerk_publishable_key` check

- SignedIn/UserButton render nothing when Clerk unavailable; SignedOut shows content

- Updated PublicNavigation to use safe wrappers instead of direct imports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Clerk Components<br/>SignedIn, SignedOut, UserButton"] -->|"Wrapped by"| B["ClerkComponents.tsx<br/>Safe Wrappers"]
  B -->|"Check availability"| C["window.__clerk_publishable_key"]
  C -->|"Available"| D["Render Clerk Components"]
  C -->|"Bypassed"| E["Graceful Fallback<br/>SignedOut shows content"]
  B -->|"Used by"| F["PublicNavigation.tsx"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClerkComponents.tsx</strong><dd><code>Safe Clerk component wrappers with bypass detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/auth/ClerkComponents.tsx

<ul><li>Created three safe wrapper components: <code>SignedIn</code>, <code>SignedOut</code>, and <br><code>UserButton</code><br> <li> Each wrapper detects Clerk availability by checking <br><code>window.__clerk_publishable_key</code><br> <li> <code>SignedIn</code> and <code>UserButton</code> render nothing when Clerk is bypassed<br> <li> <code>SignedOut</code> renders children when Clerk is bypassed or unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/300/files#diff-917af66ce6d59f94658fa2de61bae72182b375f4f95bd121b6873cace38cf742">+103/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PublicNavigation.tsx</strong><dd><code>Update imports to use safe Clerk wrappers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/navigation/PublicNavigation.tsx

<ul><li>Removed direct imports from <code>@clerk/nextjs</code><br> <li> Added import from new <code>../auth/ClerkComponents</code> safe wrapper module<br> <li> No functional changes to component logic, only import source updated</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/300/files#diff-2a80d8b278b369449c70b9578bff12b2303ecfa0d3faf500a08470209e5cbce9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

