### PR TITLE
fix: correct price display - remove /100 division

### DIFF
--- a/components/CourseDetail.tsx
+++ b/components/CourseDetail.tsx
@@ -131,7 +131,7 @@ const CourseDetail: React.FC<CourseDetailProps> = ({
     return new Intl.NumberFormat('de-DE', {
       style: 'currency',
       currency: currency.toUpperCase(),
-    }).format(amount / 100);
+    }).format(amount);
   };
 
   const handleBookNow = async (


### PR DESCRIPTION
### **User description**
## Problem
Price is displayed as 3,00 € instead of 300 €

## Cause
The `formatCurrency` function in CourseDetail.tsx was dividing by 100, assuming prices were stored in cents. However, prices are stored in EUR (full units).

## Fix
Remove the `/ 100` division from the price formatting.

## Testing
- Check https://www.hemera.academy/courses/grundkurs after deployment
- Price should show 300 € instead of 3,00 €


___

### **PR Type**
Bug fix


___

### **Description**
- Remove incorrect /100 division in price formatting

- Prices stored in EUR units, not cents

- Fixes display showing 3.00€ instead of 300€


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["formatCurrency function"] -- "removed /100 division" --> B["correct price display"]
  C["amount in EUR"] -- "direct format" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CourseDetail.tsx</strong><dd><code>Remove division in currency formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/CourseDetail.tsx

<ul><li>Removed <code>/100</code> division from <code>Intl.NumberFormat().format()</code> call<br> <li> Price now displays correctly as full EUR units instead of cents<br> <li> Fixes price display from 3.00€ to 300€</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/320/files#diff-939e8fba04701deb8a53229ce00c8e7c860d66adcb7c21e57120d94b9de5d939">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

