### PR TITLE
fix: display whole euro amounts without decimals

### DIFF
--- a/components/CourseDetail.tsx
+++ b/components/CourseDetail.tsx
@@ -129,10 +129,13 @@ const CourseDetail: React.FC<CourseDetailProps> = ({
     }
 
     // Prices are stored in cents, convert to euros for display
+    const euros = amount / 100;
     return new Intl.NumberFormat('de-DE', {
       style: 'currency',
       currency: currency.toUpperCase(),
-    }).format(amount / 100);
+      minimumFractionDigits: Number.isInteger(euros) ? 0 : 2,
+      maximumFractionDigits: 2,
+    }).format(euros);
   };
 
   const handleBookNow = async (


### PR DESCRIPTION
### **User description**
300,00 € → 300 €
99,99 € stays as 99,99 €


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Format whole euro amounts without decimal places

- Keep fractional amounts with two decimal places

- Use dynamic fraction digits based on amount value


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Price in cents"] -->|"divide by 100"| B["Amount in euros"]
  B -->|"check if integer"| C{"Is whole number?"}
  C -->|"yes"| D["0 decimal places"]
  C -->|"no"| E["2 decimal places"]
  D -->|"format"| F["300 €"]
  E -->|"format"| G["99,99 €"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CourseDetail.tsx</strong><dd><code>Add conditional decimal formatting for currency display</code>&nbsp; &nbsp; </dd></summary>
<hr>

components/CourseDetail.tsx

<ul><li>Extract euro conversion to variable for reusability<br> <li> Add dynamic <code>minimumFractionDigits</code> based on integer check<br> <li> Set <code>maximumFractionDigits</code> to 2 for consistent formatting<br> <li> Whole amounts display without decimals, fractional amounts keep 2 <br>decimals</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/322/files#diff-939e8fba04701deb8a53229ce00c8e7c860d66adcb7c21e57120d94b9de5d939">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

