### PR TITLE
fix: add Vercel Blob Storage to allowed image hosts

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,10 @@ const nextConfig = {
         protocol: 'https',
         hostname: '*.ionoscloud.com',
       },
+      {
+        protocol: 'https',
+        hostname: '*.public.blob.vercel-storage.com',
+      },
     ],
   },
 


### PR DESCRIPTION
### **User description**
Fixes next/image error for thumbnails uploaded to Vercel Blob Storage.

Added `*.public.blob.vercel-storage.com` to remotePatterns in next.config.mjs.


___

### **PR Type**
Bug fix


___

### **Description**
- Add Vercel Blob Storage domain to Next.js image remotePatterns

- Enables next/image to load thumbnails from `*.public.blob.vercel-storage.com`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["next.config.mjs"] -- "Add remotePatterns entry" --> B["Vercel Blob Storage domain"]
  B -- "Allows next/image" --> C["Load thumbnails from Vercel Blob"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.mjs</strong><dd><code>Add Vercel Blob Storage to image remotePatterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.mjs

<ul><li>Added new remotePatterns entry for Vercel Blob Storage<br> <li> Configured HTTPS protocol with wildcard hostname <br><code>*.public.blob.vercel-storage.com</code><br> <li> Enables Next.js Image Optimization to load images from Vercel Blob <br>Storage</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/324/files#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

