### PR TITLE
fix(config): correct cspell language locale format

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,7 +1,7 @@
 ---
 $schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
 version: "0.2"
-language: en,de,de_DE
+language: en,de-DE
 import:
   - "@cspell/dict-de-de/cspell-ext.json"
 useGitignore: true


### PR DESCRIPTION
### **User description**
## Summary
Fixes cspell configuration loader error for spellcheck on worktree background activity.

## Changes
- Changed language from `en,de,de_DE` to `en,de-DE`
- Fixed invalid locale code (underscore → hyphen)
- Removed redundant `de` locale (already covered by `de-DE`)

## Root Cause
The locale code `de_DE` with underscore is not valid for cspell - the correct format is `de-DE` with a hyphen.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed invalid cspell locale format from underscore to hyphen

- Changed language configuration from `en,de,de_DE` to `en,de-DE`

- Removed redundant `de` locale already covered by `de-DE`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cspell.config.yaml<br/>language: en,de,de_DE"] -- "Fix locale format<br/>underscore to hyphen" --> B["cspell.config.yaml<br/>language: en,de-DE"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cspell.config.yaml</strong><dd><code>Correct cspell language locale format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cspell.config.yaml

<ul><li>Updated <code>language</code> field from <code>en,de,de_DE</code> to <code>en,de-DE</code><br> <li> Corrected invalid locale code format using hyphen instead of <br>underscore<br> <li> Removed redundant <code>de</code> locale specification</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/335/files#diff-ba28c8d282ca58005aabe5a8d32713d35c2710f00219765dceae9b9895ab8277">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

