### PR TITLE
Fix featured courses fallback

### DIFF
--- a/lib/api/courses.ts
+++ b/lib/api/courses.ts
@@ -193,12 +193,13 @@ export async function getFeaturedCourses(limit = 3): Promise<Course[]> {
         orderError.code === 'P2022'
       ) {
         console.warn(
-          '[getFeaturedCourses] falling back to createdAt ordering',
-          {
-            code: orderError.code,
-            message: orderError.message,
-          }
+          '[getFeaturedCourses] falling back to createdAt ordering (schema mismatch detected)'
         );
+
+        logError(orderError, {
+          operation: 'getFeaturedCourses',
+          fallback: 'createdAt-ordering',
+        });
 
         courses = await fetchCourses([{ createdAt: 'desc' }]);
       } else {


### PR DESCRIPTION
### **User description**
## Summary
- add Prisma import so we can inspect known errors
- wrap featured courses query with fallback ordering when start_date column missing
- keep homepage/dashboard working even if DB schema temporarily lacks start_date

## Testing
- npm run lint


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add Prisma import to handle known database errors

- Wrap featured courses query with fallback ordering mechanism

- Fall back to createdAt ordering when startDate column missing

- Keep homepage/dashboard functional during schema transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getFeaturedCourses request"] --> B["Query with startDate ordering"]
  B --> C{startDate column exists?}
  C -->|Yes| D["Return courses sorted by startDate"]
  C -->|No - P2022 error| E["Log warning with error details"]
  E --> F["Retry with createdAt ordering"]
  F --> G["Return courses sorted by createdAt"]
  C -->|Other error| H["Throw error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>courses.ts</strong><dd><code>Add error handling and fallback ordering for featured courses</code></dd></summary>
<hr>

lib/api/courses.ts

<ul><li>Import <code>Prisma</code> from @prisma/client to detect known request errors<br> <li> Wrap <code>getFeaturedCourses</code> query in try-catch block with nested error <br>handling<br> <li> Catch P2022 error (missing column) and retry with fallback <code>createdAt</code> <br>ordering<br> <li> Log warning message when fallback is triggered with error code and <br>message</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/348/files#diff-ba4b22352b4162a05b82a9ecb7760f3aa4d0b12fad742448c9bf45f225f07bea">+53/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

