### PR TITLE
fix: convert cents to euros in checkout price display

### DIFF
--- a/components/payment/StripeCheckoutForm.tsx
+++ b/components/payment/StripeCheckoutForm.tsx
@@ -181,7 +181,7 @@ export default function StripeCheckoutForm({
       </Typography>
 
       <Typography variant='h6' color='primary' gutterBottom>
-        {amount.toLocaleString('de-DE', {
+        {(amount / 100).toLocaleString('de-DE', {
           style: 'currency',
           currency: currency.toUpperCase(),
         })}
@@ -251,7 +251,7 @@ export default function StripeCheckoutForm({
               Verarbeitung ...
             </>
           ) : (
-            `Jetzt ${amount.toLocaleString('de-DE', { style: 'currency', currency: currency.toUpperCase() })} zahlen`
+            `Jetzt ${(amount / 100).toLocaleString('de-DE', { style: 'currency', currency: currency.toUpperCase() })} zahlen`
           )}
         </Button>
 


### PR DESCRIPTION
### **User description**
## Problem
Der Checkout zeigte 30.000,00 € statt 300,00 € an.

## Ursache
Die API gibt den Betrag in Cents zurück (30000 für 300€), aber das Checkout-Formular formatierte diesen Wert direkt als Euro-Betrag.

## Lösung
Betrag durch 100 teilen, bevor er mit `toLocaleString` formatiert wird.

## Testing
- [x] TypeScript-Kompilierung erfolgreich
- [ ] Manueller Test im Production-Checkout


___

### **PR Type**
Bug fix


___

### **Description**
- Fix checkout price display showing incorrect euro amounts

- Convert API amount from cents to euros before formatting

- Apply conversion in two display locations: price summary and payment button


___

### Diagram Walkthrough


```mermaid
flowchart LR
  API["API returns amount in cents<br/>e.g., 30000"]
  BEFORE["Before: Direct formatting<br/>30.000,00 €"]
  AFTER["After: Divide by 100<br/>300,00 €"]
  API -->|"amount / 100"| AFTER
  API -->|"no conversion"| BEFORE
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StripeCheckoutForm.tsx</strong><dd><code>Convert cents to euros in price displays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/payment/StripeCheckoutForm.tsx

<ul><li>Divide <code>amount</code> by 100 in price summary display (line 183)<br> <li> Divide <code>amount</code> by 100 in payment button text (line 254)<br> <li> Ensures API cents value is correctly converted to euros before locale <br>formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/Laparo/hemera/pull/354/files#diff-4e8debcddd0d54a70e9c158160c1f1b00e8f9610bf67b3a9b528cd5d3aa16ae6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

