### PR TITLE
feat: Add service API materials endpoint for aither Spec 006

### DIFF
--- a/app/api/service/courses/[id]/materials/route.ts
+++ b/app/api/service/courses/[id]/materials/route.ts
@@ -24,7 +24,41 @@ import {
 // Force dynamic rendering
 export const dynamic = 'force-dynamic';
 
+// Zod schemas for type-safe parsing (PR #444 fix: type safety)
+const CurriculumTopicSchema = z.object({
+  id: z.string(),
+  timeRange: z.string(),
+  title: z.string(),
+});
+
+const CurriculumModuleSchema = z.object({
+  id: z.string(),
+  day: z.number(),
+  title: z.string(),
+  topics: z.array(CurriculumTopicSchema),
+});
+
+const CurriculumSchema = z.array(CurriculumModuleSchema).nullable();
+
+// Allowed Vercel Blob domains (SSRF protection)
+const ALLOWED_BLOB_DOMAINS = ['blob.vercel-storage.com'];
+
 const IdParamSchema = z.string().cuid('Invalid course ID format');
+
+/**
+ * Validates blob URL before fetching (security: SSRF protection)
+ */
+function isAllowedBlobUrl(url: string): boolean {
+  try {
+    const { hostname, protocol } = new URL(url);
+    return (
+      protocol === 'https:' &&
+      ALLOWED_BLOB_DOMAINS.some(domain => hostname.endsWith(domain))
+    );
+  } catch {
+    return false;
+  }
+}
 
 /**
  * OPTIONS /api/service/courses/[id]/materials
@@ -36,10 +70,16 @@ export async function OPTIONS(request: NextRequest) {
 }
 
 /**
- * Fetch HTML content from Vercel Blob with timeout.
+ * Fetch HTML content from Vercel Blob with timeout and URL validation.
  * Returns the HTML string or null on failure.
+ * Security: validates URL before fetching (SSRF protection)
  */
 async function fetchBlobContent(blobUrl: string): Promise<string | null> {
+  // Validate blob URL before fetching (security: SSRF protection)
+  if (!isAllowedBlobUrl(blobUrl)) {
+    return null;
+  }
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10_000);
   try {
@@ -136,17 +176,16 @@ export async function GET(
     // Load material links grouped by topicId
     const materialLinks = await getMaterialLinksForCourse(id);
 
-    // Parse curriculum JSON to get topic titles
-    const curriculum = course.curriculum as Array<{
-      id: string;
-      day: number;
-      title: string;
-      topics: Array<{
-        id: string;
-        timeRange: string;
-        title: string;
-      }>;
-    }> | null;
+    // Parse and validate curriculum JSON (type-safe with Zod, PR #444 fix: type safety)
+    const curriculumResult = CurriculumSchema.safeParse(course.curriculum);
+    if (!curriculumResult.success) {
+      logger.warn('Invalid curriculum JSON format', {
+        courseId: id,
+        parseError: curriculumResult.error.message,
+      });
+    }
+
+    const curriculum = curriculumResult.success ? curriculumResult.data : null;
 
     // Build a topicId → topicTitle lookup from curriculum JSON
     const topicTitleMap = new Map<string, string>();
@@ -171,20 +210,26 @@ export async function GET(
       where: { id: { in: [...allMaterialIds] } },
       select: { id: true, blobUrl: true },
     });
-    // Fetch all HTML contents in parallel
+
+    // Fetch HTML contents with concurrency limit (max 5 simultaneous batches)
+    // PR #444 fix: prevents overwhelming Vercel Blob service
     const htmlContentMap = new Map<string, string>();
-    const fetchPromises = materials.map(async m => {
-      const html = await fetchBlobContent(m.blobUrl);
-      if (html !== null) {
-        htmlContentMap.set(m.id, html);
-      } else {
-        logger.warn('Failed to fetch blob content for material', {
-          materialId: m.id,
-          blobUrl: m.blobUrl,
-        });
-      }
-    });
-    await Promise.all(fetchPromises);
+    const batchSize = 5;
+    for (let i = 0; i < materials.length; i += batchSize) {
+      const batch = materials.slice(i, i + batchSize);
+      const fetchPromises = batch.map(async m => {
+        const html = await fetchBlobContent(m.blobUrl);
+        if (html !== null) {
+          htmlContentMap.set(m.id, html);
+        } else {
+          logger.warn('Failed to fetch blob content for material', {
+            materialId: m.id,
+            reason: 'invalid URL, fetch timeout, or non-2xx response',
+          });
+        }
+      });
+      await Promise.all(fetchPromises);
+    }
 
     // Build response: array of topic groups with materials
     const topics: Array<{

--- a/app/api/service/courses/[id]/materials/route.ts
+++ b/app/api/service/courses/[id]/materials/route.ts
@@ -1,0 +1,254 @@
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getMaterialLinksForCourse } from '@/lib/api/curriculum-material';
+import { handleServiceAuthError } from '@/lib/auth/handle-service-auth';
+import { authenticateServiceRequest } from '@/lib/auth/service-auth';
+import { prisma } from '@/lib/db/prisma';
+import { checkRateLimit } from '@/lib/middleware/rate-limit';
+import {
+  extractIpAddress,
+  logServiceApiCall,
+} from '@/lib/monitoring/service-api-logger';
+import { createApiLogger } from '@/lib/utils/api-logger';
+import { ErrorCodes } from '@/lib/utils/api-response';
+import {
+  createRequestContext,
+  getOrCreateRequestId,
+} from '@/lib/utils/request-id';
+import {
+  createServiceApiErrorResponse,
+  createServiceApiSuccessResponse,
+  handleOptionsRequest,
+} from '@/lib/utils/service-api-response';
+
+// Force dynamic rendering
+export const dynamic = 'force-dynamic';
+
+const IdParamSchema = z.string().cuid('Invalid course ID format');
+
+/**
+ * OPTIONS /api/service/courses/[id]/materials
+ * Handle CORS preflight requests
+ */
+export async function OPTIONS(request: NextRequest) {
+  const requestId = getOrCreateRequestId(request);
+  return handleOptionsRequest(requestId);
+}
+
+/**
+ * Fetch HTML content from Vercel Blob with timeout.
+ * Returns the HTML string or null on failure.
+ */
+async function fetchBlobContent(blobUrl: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(blobUrl, { signal: controller.signal });
+    if (!response.ok) return null;
+    return await response.text();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * GET /api/service/courses/[id]/materials
+ * Get course materials with HTML content, grouped by curriculum topic.
+ *
+ * Returns materials linked via CurriculumTopicMaterial, including:
+ * - Topic grouping (topicId, topicTitle)
+ * - Material metadata (identifier, title, sortOrder)
+ * - Full HTML body fetched from Vercel Blob
+ *
+ * Auth: api-client or admin role required
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: rawId } = await params;
+  const requestId = getOrCreateRequestId(request);
+
+  // Validate ID format
+  const idResult = IdParamSchema.safeParse(rawId);
+  if (!idResult.success) {
+    return await createServiceApiErrorResponse(
+      'Invalid course ID format',
+      ErrorCodes.VALIDATION_ERROR,
+      requestId,
+      400
+    );
+  }
+  const id = idResult.data;
+
+  const context = createRequestContext(
+    requestId,
+    'GET',
+    `/api/service/courses/${id}/materials`
+  );
+  const logger = createApiLogger(context);
+  const startTime = Date.now();
+
+  try {
+    // Unified auth check (Clerk session or API key)
+    const authResult = await authenticateServiceRequest(request);
+
+    if ('error' in authResult) {
+      return await handleServiceAuthError(authResult, logger, requestId);
+    }
+
+    const { userId, role } = authResult;
+
+    logger.info('Service API materials request authorized', {
+      userId,
+      role,
+      authMethod: authResult.authMethod,
+      courseId: id,
+    });
+
+    // Rate limiting check
+    const rateLimitResponse = await checkRateLimit(userId, role, requestId);
+    if (rateLimitResponse) {
+      logger.warn('Rate limit exceeded', { userId, role });
+      return rateLimitResponse;
+    }
+
+    // Verify course exists and load curriculum JSON
+    const course = await prisma.course.findUnique({
+      where: { id },
+      select: { id: true, curriculum: true },
+    });
+
+    if (!course) {
+      logger.warn('Course not found', { courseId: id });
+      return await createServiceApiErrorResponse(
+        'Course not found',
+        ErrorCodes.NOT_FOUND,
+        requestId,
+        404,
+        userId,
+        role
+      );
+    }
+
+    // Load material links grouped by topicId
+    const materialLinks = await getMaterialLinksForCourse(id);
+
+    // Parse curriculum JSON to get topic titles
+    const curriculum = course.curriculum as Array<{
+      id: string;
+      day: number;
+      title: string;
+      topics: Array<{
+        id: string;
+        timeRange: string;
+        title: string;
+      }>;
+    }> | null;
+
+    // Build a topicId → topicTitle lookup from curriculum JSON
+    const topicTitleMap = new Map<string, string>();
+    if (curriculum) {
+      for (const mod of curriculum) {
+        for (const topic of mod.topics) {
+          topicTitleMap.set(topic.id, topic.title);
+        }
+      }
+    }
+
+    // Collect all unique materialIds to load blobUrls
+    const allMaterialIds = new Set<string>();
+    for (const links of Object.values(materialLinks)) {
+      for (const link of links) {
+        allMaterialIds.add(link.materialId);
+      }
+    }
+
+    // Load blobUrls for all materials in a single query
+    const materials = await prisma.courseMaterial.findMany({
+      where: { id: { in: [...allMaterialIds] } },
+      select: { id: true, blobUrl: true },
+    });
+    // Fetch all HTML contents in parallel
+    const htmlContentMap = new Map<string, string>();
+    const fetchPromises = materials.map(async m => {
+      const html = await fetchBlobContent(m.blobUrl);
+      if (html !== null) {
+        htmlContentMap.set(m.id, html);
+      } else {
+        logger.warn('Failed to fetch blob content for material', {
+          materialId: m.id,
+          blobUrl: m.blobUrl,
+        });
+      }
+    });
+    await Promise.all(fetchPromises);
+
+    // Build response: array of topic groups with materials
+    const topics: Array<{
+      topicId: string;
+      topicTitle: string;
+      materials: Array<{
+        materialId: string;
+        identifier: string;
+        title: string;
+        sortOrder: number;
+        htmlContent: string | null;
+      }>;
+    }> = [];
+
+    for (const [topicId, links] of Object.entries(materialLinks)) {
+      topics.push({
+        topicId,
+        topicTitle: topicTitleMap.get(topicId) ?? topicId,
+        materials: links.map(link => ({
+          materialId: link.materialId,
+          identifier: link.identifier,
+          title: link.title,
+          sortOrder: link.sortOrder,
+          htmlContent: htmlContentMap.get(link.materialId) ?? null,
+        })),
+      });
+    }
+
+    const totalMaterials = topics.reduce(
+      (sum, t) => sum + t.materials.length,
+      0
+    );
+
+    logger.info('Course materials retrieved successfully', {
+      courseId: id,
+      topicCount: topics.length,
+      materialCount: totalMaterials,
+    });
+
+    // Audit log
+    logServiceApiCall({
+      userId,
+      userRole: role,
+      endpoint: `/api/service/courses/${id}/materials`,
+      method: 'GET',
+      statusCode: 200,
+      requestId,
+      timestamp: new Date().toISOString(),
+      ipAddress: extractIpAddress(request.headers),
+      responseTime: Date.now() - startTime,
+    });
+
+    return await createServiceApiSuccessResponse(requestId, userId, role, {
+      courseId: id,
+      topics,
+    });
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error('Failed to retrieve course materials', err);
+    return await createServiceApiErrorResponse(
+      'Internal server error',
+      ErrorCodes.INTERNAL_ERROR,
+      requestId,
+      500
+    );
+  }
+}

--- a/app/api/service/courses/[id]/route.ts
+++ b/app/api/service/courses/[id]/route.ts
@@ -93,7 +93,7 @@ export async function GET(
       return rateLimitResponse;
     }
 
-    // Query course with participations
+    // Query course with participations and user data
     const course = await prisma.course.findUnique({
       where: { id },
       select: {
@@ -108,10 +108,19 @@ export async function GET(
             id: true,
             userId: true,
             createdAt: true,
+            user: {
+              select: {
+                name: true,
+              },
+            },
             participation: {
               select: {
                 id: true,
                 status: true,
+                preparationIntent: true,
+                desiredResults: true,
+                lineManagerProfile: true,
+                preparationCompletedAt: true,
                 createdAt: true,
               },
             },
@@ -134,7 +143,20 @@ export async function GET(
       );
     }
 
-    // Transform response
+    // Transform response — includes both `participants` (for aither) and
+    // `participations` (legacy consumers) to avoid breaking changes.
+    const participants = course.bookings.map(booking => ({
+      participationId: booking.participation?.id ?? null,
+      userId: booking.userId,
+      name: booking.user?.name ?? null,
+      status: booking.participation?.status ?? 'NONE',
+      preparationIntent: booking.participation?.preparationIntent ?? null,
+      desiredResults: booking.participation?.desiredResults ?? null,
+      lineManagerProfile: booking.participation?.lineManagerProfile ?? null,
+      preparationCompletedAt:
+        booking.participation?.preparationCompletedAt?.toISOString() ?? null,
+    }));
+
     const data = {
       id: course.id,
       title: course.title,
@@ -142,6 +164,7 @@ export async function GET(
       level: course.level,
       startDate: course.startDate?.toISOString() ?? null,
       endDate: course.endDate?.toISOString() ?? null,
+      participants,
       participations: course.bookings.map(booking => ({
         id: booking.participation?.id ?? null,
         userId: booking.userId,


### PR DESCRIPTION
## Service API: Materials Endpoint (aither Spec 006 Integration)

Adds new materials endpoint to support aither's participant slide generation pipeline.

### What's New

**New Endpoint**: `GET /api/service/courses/[id]/materials`
- Fetches course materials with curriculum links and HTML content
- Returns structured data for template engine processing

**Enhanced Endpoint**: `GET /api/service/courses/[id]`
- Now includes participant preparation data: `preparationIntent`, `desiredResults`, `lineManagerProfile`, `preparationCompletedAt`
- New `participants[]` array in response for aither integration
- Maintains backwards compatibility with existing `participations[]` field

### Implementation Details

- Blob content fetching with 10s timeout for HTML material processing
- Rate limiting and authentication checks on both endpoints
- Structured logging and audit trails
- Error isolation (materials API failures don't block course detail fetch)

### Quality Gates

- ✅ TypeScript: 0 errors (strict mode)
- ✅ Biome: 0 issues (402 files)
- ✅ All tests passing

### Related to

- aither Spec 006: Participant Slides (Task T021)
- hemera PR #15 merged: Template engine with Mode A/B distribution

---

**Spec reference**: `aither/specs/006-participant-slides/spec.md`
**API contract**: `aither/src/lib/hemera/schemas.ts` (Service API schemas)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Features**
  * Neuer API‑Endpunkt zum Abrufen von Kursmaterialien, gruppiert nach Lehrplanthemen, mit HTML‑Inhalt und CORS‑Unterstützung.

* **Verbesserungen**
  * Erweiterte Kursabfragen: zusätzliche Teilnehmer‑ und Vorbereitungsdaten sichtbar; neue Teilnehmerliste im Antwortpayload für reichhaltigere Teilnehmerinformationen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->