### PR TITLE
fix(ci): Use context.payload in dependabot-label workflow

### DIFF
--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -28,4 +28,4 @@ jobs:
               issue_number: context.payload.pull_request.number,
               labels: ['automerge']
             });
-            core.info(`Added 'automerge' label to PR #${context.payload.pull_request.number} (${github.event.pull_request.title})`);
+            core.info(`Added 'automerge' label to PR #${context.payload.pull_request.number} (${context.payload.pull_request.title})`);


### PR DESCRIPTION
Fix failing `label-automerge` check on Dependabot PRs.

**Problem:** `github.event.pull_request.title` is undefined in `actions/github-script` — the correct API is `context.payload.pull_request.title`.

**Impact:** All Dependabot PRs (e.g. #461) fail the label-automerge step.

**Fix:** Replace with `context.payload.pull_request.title`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Interne Wartung der Continuous-Integration-Workflows ohne Auswirkungen auf die Endbenutzerfunktionalität.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->