### PR TITLE
fix(ci): simplify Dependabot automerge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -49,35 +49,23 @@ jobs:
           echo "Major version update detected. Skipping auto-merge."
           exit 1
 
-      - name: Wait for required checks
+      - name: Approve PR
+        run: gh pr review "$PR_NUMBER" --approve
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for build-and-test
         uses: lewagon/wait-on-check-action@v1.6.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20
+          check-name: build-and-test
           allowed-conclusions: success
-          running-workflow-name: 'automerge'
-
-      - name: Enable auto-merge
-        if: ${{ github.event.pull_request.auto_merge == null }}
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          pull-request-number: ${{ github.event.pull_request.number }}
-          merge-method: squash
 
       - name: Merge Dependabot PR
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            try {
-              await github.rest.pulls.merge({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-                merge_method: 'squash',
-              });
-              core.info(`Merged PR #${pr.number}`);
-            } catch (e) {
-              core.info(`Skip merge for PR #${pr.number}: ${e.message}`);
-            }
+        run: gh pr merge "$PR_NUMBER" --squash --admin
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Änderungen

**Branch Protection (permanent):**
- `require_code_owner_reviews: false` — war für Solo-Developer immer kaputt (kann eigene PRs nicht approven)
- `enforce_admins: false` — erlaubt Admin-Bypass für Workflow-Merges

**Workflow:**
- **Approve PR**: Workflow approved die PR automatisch (erfüllt Review-Gate)
- **Wait for build-and-test only**: Wartet nur auf den Build-Check, nicht auf Preview Deployment
- **Merge with --admin**: Direkter Squash-Merge mit Admin-Bypass
- Entfernt `peter-evans/enable-pull-request-automerge` Dependency
- Entfernt `actions/github-script` Merge-Fallback

**Ergebnis:** Dependabot minor/patch PRs werden automatisch gemerged nachdem `build-and-test` grün ist. Major Updates werden weiterhin blockiert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Aktualisierte GitHub Actions Workflow für automatisierte Abhängigkeitsverwaltung mit verbesserter CI/CD-Integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->