### PR TITLE
Fix dashboard status typing and profile routing regressions

### DIFF
--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -5,6 +5,8 @@ import { z } from 'zod';
 import { prisma } from '@/lib/db/prisma';
 import { logError } from '@/lib/errors';
 import { ErrorSeverity, reportError } from '@/lib/monitoring/rollbar-official';
+import type { PaymentStatus as ApiPaymentStatus } from '@/lib/types/booking';
+import type { ParticipationStatus as ApiParticipationStatus } from '@/lib/types/participation';
 import { isClerkDisabled } from '@/lib/utils/clerk-disabled-check';
 
 const BookingQuerySchema = z.object({
@@ -80,7 +82,30 @@ type BookingRecord = {
   } | null;
 };
 
-function normalizeBookings(bookings: BookingRecord[], requestId: string) {
+type NormalizedBookingRecord = {
+  id: string;
+  courseId: string;
+  courseTitle: string;
+  coursePrice: number;
+  currency: string;
+  paymentStatus: ApiPaymentStatus;
+  createdAt: string;
+  startDate: string | null;
+  endDate: string | null;
+  startTime: string | null;
+  endTime: string | null;
+  locationName: string | null;
+  locationSlug: string | null;
+  locationCity: string | null;
+  hasParticipation: boolean;
+  participationStatus: ApiParticipationStatus | null;
+  stripeInvoicePdfUrl: string | null;
+};
+
+function normalizeBookings(
+  bookings: BookingRecord[],
+  requestId: string
+): NormalizedBookingRecord[] {
   return bookings.map(booking => {
     if (!booking.course) {
       reportError(
@@ -103,7 +128,7 @@ function normalizeBookings(bookings: BookingRecord[], requestId: string) {
       coursePrice: booking.amount ?? 0,
       currency: booking.currency ?? 'EUR',
       paymentStatus: booking.paymentStatus,
-      createdAt: booking.createdAt,
+      createdAt: booking.createdAt.toISOString(),
       // New fields for dashboard
       startDate: booking.course?.startDate?.toISOString() ?? null,
       endDate: booking.course?.endDate?.toISOString() ?? null,

--- a/app/e2e/stepper-debug/StepperDebugClient.tsx
+++ b/app/e2e/stepper-debug/StepperDebugClient.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Box, Typography } from '@mui/material';
-import type { ParticipationStatus } from '@prisma/client';
 import CourseProgressStepper from '@/components/dashboard/CourseProgressStepper';
+import type { ParticipationStatus } from '@/lib/types/participation';
 
 const statuses: (ParticipationStatus | null)[] = [
   null,

--- a/app/my-courses/[bookingId]/nachbereitung/page.tsx
+++ b/app/my-courses/[bookingId]/nachbereitung/page.tsx
@@ -10,6 +10,7 @@ import { Alert, Box, Typography } from '@mui/material';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import type React from 'react';
 import DebriefingVideoCatalog from '@/components/participation/DebriefingVideoCatalog';
 import { requireAuthenticatedUser } from '@/lib/auth/helpers';
 import { getResolvedSummaryAssets } from '@/lib/db/courseParticipation';
@@ -29,7 +30,9 @@ interface PageProps {
   params: Promise<{ bookingId: string }>;
 }
 
-export default async function NachbereitungPage({ params }: PageProps) {
+export default async function NachbereitungPage({
+  params,
+}: PageProps): Promise<React.ReactElement> {
   const { bookingId } = await params;
   const user = await requireAuthenticatedUser();
 
@@ -79,26 +82,29 @@ export default async function NachbereitungPage({ params }: PageProps) {
 
   return (
     <Box sx={{ maxWidth: 960, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
-      <Link
+      <Box
+        component={Link}
         href='/dashboard'
-        style={{ textDecoration: 'none' }}
         aria-label='Zurück zum Dashboard'
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          textDecoration: 'none',
+          color: colors.marsala,
+          fontFamily: typography.body,
+          fontSize: '0.875rem',
+          mb: 2,
+          borderRadius: '4px',
+          '&:focus-visible': {
+            outline: `2px solid ${colors.marsala}`,
+            outlineOffset: '2px',
+          },
+        }}
       >
-        <Box
-          sx={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 0.5,
-            color: colors.marsala,
-            fontFamily: typography.body,
-            fontSize: '0.875rem',
-            mb: 2,
-          }}
-        >
-          <ArrowBackOutlined sx={{ fontSize: 18 }} />
-          Zurück zum Dashboard
-        </Box>
-      </Link>
+        <ArrowBackOutlined sx={{ fontSize: 18 }} />
+        Zurück zum Dashboard
+      </Box>
 
       <Typography
         component='h1'

--- a/app/my-courses/[bookingId]/seminarveranstaltung/page.tsx
+++ b/app/my-courses/[bookingId]/seminarveranstaltung/page.tsx
@@ -81,26 +81,29 @@ export default async function SeminarveranstaltungPage({
 
   return (
     <Box sx={{ maxWidth: 960, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
-      <Link
+      <Box
+        component={Link}
         href='/dashboard'
-        style={{ textDecoration: 'none' }}
         aria-label='Zurück zum Dashboard'
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          textDecoration: 'none',
+          color: colors.marsala,
+          fontFamily: typography.body,
+          fontSize: '0.875rem',
+          mb: 2,
+          borderRadius: '4px',
+          '&:focus-visible': {
+            outline: `2px solid ${colors.marsala}`,
+            outlineOffset: '2px',
+          },
+        }}
       >
-        <Box
-          sx={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 0.5,
-            color: colors.marsala,
-            fontFamily: typography.body,
-            fontSize: '0.875rem',
-            mb: 2,
-          }}
-        >
-          <ArrowBackOutlined sx={{ fontSize: 18 }} />
-          Zurück zum Dashboard
-        </Box>
-      </Link>
+        <ArrowBackOutlined sx={{ fontSize: 18 }} />
+        Zurück zum Dashboard
+      </Box>
 
       <Typography
         component='h1'

--- a/app/my-courses/[bookingId]/verhandlungsergebnis/page.tsx
+++ b/app/my-courses/[bookingId]/verhandlungsergebnis/page.tsx
@@ -82,31 +82,29 @@ export default async function VerhandlungsergebnisPage({
 
   return (
     <Box sx={{ maxWidth: 960, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
-      <Link
+      <Box
+        component={Link}
         href='/dashboard'
-        style={{ textDecoration: 'none' }}
         aria-label='Zurück zum Dashboard'
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          textDecoration: 'none',
+          color: colors.marsala,
+          fontFamily: typography.body,
+          fontSize: '0.875rem',
+          mb: 2,
+          borderRadius: '4px',
+          '&:focus-visible': {
+            outline: `2px solid ${colors.marsala}`,
+            outlineOffset: '2px',
+          },
+        }}
       >
-        <Box
-          sx={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 0.5,
-            color: colors.marsala,
-            fontFamily: typography.body,
-            fontSize: '0.875rem',
-            mb: 2,
-            borderRadius: '4px',
-            '&:focus-visible': {
-              outline: `2px solid ${colors.marsala}`,
-              outlineOffset: '2px',
-            },
-          }}
-        >
-          <ArrowBackOutlined aria-hidden='true' sx={{ fontSize: 18 }} />
-          Zurück zum Dashboard
-        </Box>
-      </Link>
+        <ArrowBackOutlined aria-hidden='true' sx={{ fontSize: 18 }} />
+        Zurück zum Dashboard
+      </Box>
 
       <Typography
         component='h1'

--- a/app/my-courses/[bookingId]/vorbereitung/page.tsx
+++ b/app/my-courses/[bookingId]/vorbereitung/page.tsx
@@ -11,6 +11,7 @@ import { Box, Typography } from '@mui/material';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import type React from 'react';
 import { requireAuthenticatedUser } from '@/lib/auth/helpers';
 import { prisma } from '@/lib/db/prisma';
 import { colors, typography } from '@/lib/design-tokens';
@@ -28,7 +29,9 @@ interface PageProps {
   params: Promise<{ bookingId: string }>;
 }
 
-export default async function VorbereitungPage({ params }: PageProps) {
+export default async function VorbereitungPage({
+  params,
+}: PageProps): Promise<React.ReactElement> {
   const { bookingId } = await params;
   const user = await requireAuthenticatedUser();
 
@@ -60,26 +63,29 @@ export default async function VorbereitungPage({ params }: PageProps) {
 
   return (
     <Box sx={{ maxWidth: 960, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
-      <Link
+      <Box
+        component={Link}
         href='/dashboard'
-        style={{ textDecoration: 'none' }}
         aria-label='Zurück zum Dashboard'
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          textDecoration: 'none',
+          color: colors.marsala,
+          fontFamily: typography.body,
+          fontSize: '0.875rem',
+          mb: 2,
+          borderRadius: '4px',
+          '&:focus-visible': {
+            outline: `2px solid ${colors.marsala}`,
+            outlineOffset: '2px',
+          },
+        }}
       >
-        <Box
-          sx={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 0.5,
-            color: colors.marsala,
-            fontFamily: typography.body,
-            fontSize: '0.875rem',
-            mb: 2,
-          }}
-        >
-          <ArrowBackOutlined sx={{ fontSize: 18 }} />
-          Zurück zum Dashboard
-        </Box>
-      </Link>
+        <ArrowBackOutlined sx={{ fontSize: 18 }} />
+        Zurück zum Dashboard
+      </Box>
 
       <Typography
         component='h1'

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/components/CourseDetail.tsx
+++ b/components/CourseDetail.tsx
@@ -200,6 +200,14 @@ const CourseDetail: React.FC<CourseDetailProps> = ({
     return formatDate(course.startDate) ?? null;
   }, [course.startDate]);
 
+  const bookingButtonLinkProps =
+    bookNowHref && !isBookingDisabled
+      ? {
+          component: Link as React.ElementType,
+          href: bookNowHref,
+        }
+      : {};
+
   const formattedTime = useMemo(() => {
     if (!course.startTime || !course.endTime) return null;
     const startTime =
@@ -447,18 +455,12 @@ const CourseDetail: React.FC<CourseDetailProps> = ({
                   variant='contained'
                   size='large'
                   startIcon={<BookOnlineOutlinedIcon />}
-                  {...(bookNowHref
-                    ? {
-                        component: Link as React.ElementType,
-                        href: bookNowHref,
-                      }
-                    : {})}
+                  {...bookingButtonLinkProps}
                   onClick={
                     typeof onBookNow === 'function' ? handleBookNow : undefined
                   }
                   disabled={isBookingDisabled}
                   title={disableReason ?? undefined}
-                  aria-disabled={isBookingDisabled}
                   aria-busy={isBooking || undefined}
                   data-testid='course-detail-book-cta'
                 >

--- a/components/DashboardSidebar.tsx
+++ b/components/DashboardSidebar.tsx
@@ -29,12 +29,12 @@ const routes = [
   },
   {
     path: '/my-courses',
-    name: 'My Courses',
+    name: 'Meine Kurse',
     icon: SchoolIcon,
   },
   {
-    path: '/profile',
-    name: 'Profile',
+    path: '/user-profile',
+    name: 'Profil',
     icon: PersonIcon,
   },
 ];

--- a/components/UserDashboard.tsx
+++ b/components/UserDashboard.tsx
@@ -12,7 +12,6 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import { ParticipationStatus, PaymentStatus } from '@prisma/client';
 import Link from 'next/link';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -20,6 +19,8 @@ import { z } from 'zod';
 import { TERMS } from '@/lib/constants';
 import { colors } from '@/lib/design-tokens';
 import { ErrorSeverity, reportError } from '@/lib/monitoring/rollbar-official';
+import { isPaymentStatus, type PaymentStatus } from '@/lib/types/booking';
+import { PARTICIPATION_STATUSES } from '@/lib/types/participation';
 import {
   type BookingForCategorization,
   categorizeBookings as categorizeBookingsUtil,
@@ -31,7 +32,14 @@ import {
   UserPageContainer,
 } from './dashboard';
 
-const participationStatusSchema = z.nativeEnum(ParticipationStatus).nullable();
+const participationStatusSchema = z.preprocess(
+  value => (value == null ? null : value),
+  z.union([z.enum(PARTICIPATION_STATUSES), z.null()])
+);
+
+const paymentStatusSchema = z.custom<PaymentStatus>(isPaymentStatus, {
+  message: 'Ungültiger paymentStatus',
+});
 
 const bookingSchema = z.object({
   id: z.string(),
@@ -39,7 +47,7 @@ const bookingSchema = z.object({
   courseTitle: z.string(),
   coursePrice: z.number(),
   currency: z.string(),
-  paymentStatus: z.nativeEnum(PaymentStatus),
+  paymentStatus: paymentStatusSchema,
   createdAt: z.string(),
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),

--- a/components/admin/DashboardCard.tsx
+++ b/components/admin/DashboardCard.tsx
@@ -109,7 +109,6 @@ export function DashboardCard({ config }: DashboardCardProps) {
     return (
       <Card
         data-testid={`dashboard-card-${id}`}
-        aria-disabled='true'
         sx={{
           height: '100%',
           opacity: 0.6,

--- a/components/auth/UserProfileButton.tsx
+++ b/components/auth/UserProfileButton.tsx
@@ -70,7 +70,7 @@ export function UserProfileButton({
       path: '/dashboard',
     },
     {
-      label: 'My Courses',
+      label: 'Meine Kurse',
       icon: <Settings fontSize='small' />,
       path: '/my-courses',
     },

--- a/components/dashboard/CourseCard.tsx
+++ b/components/dashboard/CourseCard.tsx
@@ -17,6 +17,7 @@ import {
 import { Box, Button, Chip, Paper, Stack, Typography } from '@mui/material';
 import Link from 'next/link';
 import { colors } from '@/lib/design-tokens';
+import type { PaymentStatus } from '@/lib/types/booking';
 import InvoiceDownloadButton from './InvoiceDownloadButton';
 import TestimonialButton from './TestimonialButton';
 
@@ -32,7 +33,7 @@ export interface CourseCardProps {
   locationSlug: string | null;
   locationCity: string | null;
   hasParticipation: boolean;
-  paymentStatus: string;
+  paymentStatus: PaymentStatus;
   stripeInvoicePdfUrl: string | null;
   /** Which section this card is displayed in */
   sectionType: 'NEXT_SEMINAR' | 'UPCOMING' | 'COMPLETED' | 'NO_SHOW';
@@ -119,7 +120,7 @@ export const getLocationDisplayText = (
  */
 const shouldShowInvoiceButton = (
   _sectionType: CourseCardProps['sectionType'],
-  paymentStatus: string,
+  paymentStatus: PaymentStatus,
   _invoiceUrl: string | null
 ): boolean => {
   // Show invoice for all paid bookings, regardless of course status

--- a/components/dashboard/CourseProgressStepper.tsx
+++ b/components/dashboard/CourseProgressStepper.tsx
@@ -14,11 +14,11 @@ import { Check } from '@mui/icons-material';
 import { Box, Step, StepLabel, Stepper, Typography } from '@mui/material';
 import type { StepIconProps } from '@mui/material/StepIcon';
 import { useTheme } from '@mui/material/styles';
-import type { ParticipationStatus } from '@prisma/client';
 import Link from 'next/link';
 import { colors, typography } from '@/lib/design-tokens';
+import type { ParticipationStatus } from '@/lib/types/participation';
 
-export type { ParticipationStatus } from '@prisma/client';
+export type { ParticipationStatus } from '@/lib/types/participation';
 
 type DashboardStepKey =
   | 'VORBEREITUNG'

--- a/components/dashboard/InvoiceDownloadButton.tsx
+++ b/components/dashboard/InvoiceDownloadButton.tsx
@@ -37,7 +37,7 @@
 'use client';
 
 import { DescriptionOutlined } from '@mui/icons-material';
-import { CircularProgress, Link as MuiLink, Tooltip } from '@mui/material';
+import { Box, CircularProgress, Tooltip } from '@mui/material';
 import { useCallback, useState } from 'react';
 import { colors, typography } from '@/lib/design-tokens';
 import { logClientError } from '@/lib/errors/client';
@@ -215,12 +215,11 @@ export default function InvoiceDownloadButton({
       : BUTTON_TEXT.DEFAULT;
 
   const link = (
-    <MuiLink
+    <Box
       component='button'
       type='button'
-      underline='hover'
       onClick={handleClick}
-      aria-disabled={buttonDisabled}
+      disabled={buttonDisabled}
       aria-label={buttonText}
       aria-busy={isLoading}
       sx={{
@@ -232,11 +231,12 @@ export default function InvoiceDownloadButton({
         fontWeight: 500,
         fontSize: '0.875rem',
         cursor: buttonDisabled ? 'not-allowed' : 'pointer',
-        pointerEvents: buttonDisabled ? 'none' : 'auto',
         opacity: buttonDisabled ? 0.5 : 1,
         border: 'none',
         background: 'none',
         p: 0,
+        textDecoration: 'underline',
+        textUnderlineOffset: '0.12em',
         '&:hover': {
           color: colors.bronze,
         },
@@ -253,7 +253,7 @@ export default function InvoiceDownloadButton({
         <DescriptionOutlined sx={{ fontSize: '1rem' }} />
       )}
       {compact ? null : buttonText}
-    </MuiLink>
+    </Box>
   );
 
   // Show tooltip on error

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -79,7 +79,7 @@ export const updateProfileAction = async (
 
     // Revalidate user-related pages
     revalidatePath('/protected');
-    revalidatePath('/profile');
+    revalidatePath('/user-profile');
 
     return {
       success: true,
@@ -121,7 +121,7 @@ export const syncUserAction = withServerActionErrorHandling(
     const user = await getCurrentUserWithSync();
 
     revalidatePath('/protected');
-    revalidatePath('/profile');
+    revalidatePath('/user-profile');
 
     return user;
   }

--- a/lib/auth/clerk-config.ts
+++ b/lib/auth/clerk-config.ts
@@ -212,7 +212,7 @@ export const clerkConfig = {
     return this.signUpFallbackRedirectUrl;
   },
   dashboardUrl: '/dashboard',
-  profileUrl: '/my-courses', // Use existing route instead of /protected/profile
+  profileUrl: '/user-profile', // Use dedicated localized profile route
 };
 
 /**

--- a/lib/types/booking.ts
+++ b/lib/types/booking.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared booking-related types used across API normalization and frontend.
+ */
+
+import type { PaymentStatus as PrismaPaymentStatus } from '@prisma/client';
+
+export const PAYMENT_STATUSES = [
+  'PENDING',
+  'PRE_BOOKED',
+  'PAID',
+  'FAILED',
+  'CANCELLED',
+  'REFUNDED',
+  'CONFIRMED',
+] as const satisfies readonly PrismaPaymentStatus[];
+
+export type PaymentStatus = PrismaPaymentStatus;
+
+type MissingPaymentStatuses = Exclude<
+  PrismaPaymentStatus,
+  (typeof PAYMENT_STATUSES)[number]
+>;
+type ExtraPaymentStatuses = Exclude<
+  (typeof PAYMENT_STATUSES)[number],
+  PrismaPaymentStatus
+>;
+type PaymentStatusesMatchBackend = [
+  MissingPaymentStatuses,
+  ExtraPaymentStatuses,
+] extends [never, never]
+  ? true
+  : never;
+
+const paymentStatusesMatchBackend: PaymentStatusesMatchBackend = true;
+
+void paymentStatusesMatchBackend;
+
+export function isPaymentStatus(value: unknown): value is PaymentStatus {
+  return (
+    typeof value === 'string' &&
+    (PAYMENT_STATUSES as readonly string[]).includes(value)
+  );
+}

--- a/lib/types/participation.ts
+++ b/lib/types/participation.ts
@@ -3,6 +3,37 @@
  * Feature: 027-user-course-management
  */
 
+import type { ParticipationStatus as PrismaParticipationStatus } from '@prisma/client';
+
+export const PARTICIPATION_STATUSES = [
+  'PREPARATION',
+  'SUMMARY',
+  'DEBRIEFING',
+  'RESULT',
+  'COMPLETE',
+] as const satisfies readonly PrismaParticipationStatus[];
+
+export type ParticipationStatus = PrismaParticipationStatus;
+
+type MissingParticipationStatuses = Exclude<
+  PrismaParticipationStatus,
+  (typeof PARTICIPATION_STATUSES)[number]
+>;
+type ExtraParticipationStatuses = Exclude<
+  (typeof PARTICIPATION_STATUSES)[number],
+  PrismaParticipationStatus
+>;
+type ParticipationStatusesMatchBackend = [
+  MissingParticipationStatuses,
+  ExtraParticipationStatuses,
+] extends [never, never]
+  ? true
+  : never;
+
+const participationStatusesMatchBackend: ParticipationStatusesMatchBackend = true;
+
+void participationStatusesMatchBackend;
+
 export const NEGOTIATION_PARTNERS = [
   'DIRECT_MANAGER',
   'SKIP_LEVEL_MANAGER',

--- a/lib/utils/booking-categorization.ts
+++ b/lib/utils/booking-categorization.ts
@@ -8,7 +8,7 @@
  * - Seminare ohne Teilnahme (past courses without participation)
  */
 
-import type { PaymentStatus } from '@prisma/client';
+import type { PaymentStatus } from '@/lib/types/booking';
 
 /**
  * Booking data required for categorization

--- a/tests/e2e/authorization.spec.ts
+++ b/tests/e2e/authorization.spec.ts
@@ -300,7 +300,7 @@ async function renderMockProfile(page: Page, role: 'user' | 'admin') {
     <html>
       <body>
         <main data-testid="profile-page">
-          <h1>Profile</h1>
+          <h1>Profil</h1>
           <p data-testid="user-role">${role}</p>
         </main>
       </body>

--- a/tests/unit/components/DashboardSidebar.spec.tsx
+++ b/tests/unit/components/DashboardSidebar.spec.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, jest } from '@jest/globals';
+import type { ReactNode } from 'react';
+
+jest.mock('next/link', () => {
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      href,
+      ...props
+    }: {
+      children: ReactNode;
+      href: string;
+      [key: string]: unknown;
+    }) => (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+}));
+
+import DashboardSidebar from '@/components/DashboardSidebar';
+
+describe('DashboardSidebar', () => {
+  it('renders all expected routes with localized labels', () => {
+    render(<DashboardSidebar />);
+
+    const dashboardLink = screen.getByRole('link', { name: /dashboard/i });
+    expect(dashboardLink).toHaveAttribute('href', '/dashboard');
+
+    const myCoursesLink = screen.getByRole('link', { name: /meine kurse/i });
+    expect(myCoursesLink).toHaveAttribute('href', '/my-courses');
+
+    const profileLink = screen.getByRole('link', { name: /profil/i });
+    expect(profileLink).toHaveAttribute('href', '/user-profile');
+  });
+
+  it('does not introduce english localization variants for sidebar routes', () => {
+    render(<DashboardSidebar />);
+
+    expect(screen.queryByRole('link', { name: /my courses/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /profile/i })).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/shared-status-types.spec.ts
+++ b/tests/unit/shared-status-types.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  ParticipationStatus as PrismaParticipationStatus,
+  PaymentStatus as PrismaPaymentStatus,
+} from '@prisma/client';
+import { PAYMENT_STATUSES, isPaymentStatus } from '@/lib/types/booking';
+import {
+  PARTICIPATION_STATUSES,
+  type ParticipationStatus,
+} from '@/lib/types/participation';
+
+describe('shared status types', () => {
+  it('mirrors Prisma PaymentStatus values exactly', () => {
+    expect(PAYMENT_STATUSES).toEqual(Object.values(PrismaPaymentStatus));
+  });
+
+  it('mirrors Prisma ParticipationStatus values exactly', () => {
+    expect(PARTICIPATION_STATUSES).toEqual(
+      Object.values(PrismaParticipationStatus)
+    );
+  });
+
+  it('accepts valid payment status values via helper', () => {
+    Object.values(PrismaPaymentStatus).forEach(status => {
+      expect(isPaymentStatus(status)).toBe(true);
+    });
+  });
+
+  it('rejects invalid payment status values via helper', () => {
+    ['PROCESSING', 'UNKNOWN', '', null, undefined].forEach(status => {
+      expect(isPaymentStatus(status)).toBe(false);
+    });
+  });
+
+  it('keeps participation status values usable as shared type literals', () => {
+    const statuses: ParticipationStatus[] = [...PARTICIPATION_STATUSES];
+
+    expect(statuses).toEqual(Object.values(PrismaParticipationStatus));
+  });
+});


### PR DESCRIPTION
## Summary
- align dashboard booking and participation status types with shared frontend-safe types derived from Prisma enums
- serialize booking API dates and localize profile and sidebar routing to /user-profile
- restore button and link semantics for dashboard and course detail actions, and add focused regression tests

## Validation
- npm run spellcheck
- extended cspell over app, src, docs, components, lib, tests
- npm run lint
- npm run typecheck
- npm test -- --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Navigationsbezeichnungen in deutscher Sprache hinzugefügt

* **Bugfixes**
  * Verbesserte Barrierefreiheit mit konsistenten visuellen Fokusmarkierungen bei Schaltflächen

* **Style**
  * Einheitliche Stilisierung von Zurück-Navigationsschaltflächen auf allen Seiten

* **Tests**
  * Neue Tests für Navigation und Statusvalidierung hinzugefügt

<!-- end of auto-generated comment: release notes by coderabbit.ai -->