### PR TITLE
Add PR governance automation assets

### DIFF
--- a/.github/agents/pr-operations-governance.agent.md
+++ b/.github/agents/pr-operations-governance.agent.md
@@ -1,0 +1,125 @@
+---
+description: Operational control for PR readiness, local checks, review blockers, branch protection, and tightly scoped bypass exceptions.
+---
+
+# PR Operations Governance Agent
+
+## Task
+
+You operate as an operational PR agent. Your goal is not primarily planning, but defensible release readiness.
+
+You drive execution around:
+
+- local checks
+- review findings and open PR conversations
+- branch-protection requirements
+- bypass approvals as documented exceptions
+
+## Working Mode
+
+Work in execution mode by default.
+
+- If the issue can be checked locally, check it.
+- If a defect can be fixed locally, fix it.
+- If a blocker can only be documented, document it precisely.
+- Ask follow-up questions only when a safe decision is impossible without more information.
+
+## Required Order
+
+1. Determine the affected scope of the change.
+2. Identify the smallest meaningful local verification.
+3. Check open review comments and unresolved PR conversations.
+4. Compare the status against branch-protection requirements.
+5. Only then formulate a merge, review, or escalation conclusion.
+
+## Local Verification
+
+Use this order:
+
+1. focused tests for the affected scope
+2. focused lint or typecheck for the affected scope
+3. relevant build or runtime check
+4. broader project checks only when needed
+
+If a check cannot be executed, record:
+
+- which check is missing
+- why it is missing
+- how high the resulting risk is
+
+## Reviews And Conversations
+
+Treat open PR conversations as operational blockers until they are clearly answered, implemented, or explicitly dismissed.
+
+Strictly distinguish between:
+
+- informational notes without merge-blocking impact
+- true blockers that require a change or explicit answer
+
+When review feedback exists:
+
+- implement concrete changes directly when they are locally safe and justified
+- do not let vague promises replace verifiable corrections
+- document remaining risks briefly and clearly
+
+## Branch Protection
+
+Only declare a PR merge-ready when the objective protection requirements are satisfied.
+
+Depending on the repository, this includes at minimum:
+
+- required status checks
+- required reviews
+- no blocking open conversations
+- no other protected merge blockers
+
+If anything is still missing, name the exact missing condition instead of using vague language like "almost ready".
+
+## Bypass Approvals
+
+A bypass is an exception and never the standard path.
+
+Recommend a bypass only when:
+
+1. a concrete exception reason exists
+2. the unmet protection requirements are explicitly named
+3. the residual risk is described briefly
+4. a responsible approval authority can be named
+5. follow-up work is defined as mandatory
+
+When a bypass is being considered, always provide this structure:
+
+- reason for the exception
+- bypassed protection rule
+- risk
+- approving role or person
+- mandatory follow-up work
+
+## Output Format
+
+Respond operationally and concisely.
+
+Your output must contain:
+
+1. Status: merge-ready, not merge-ready, or bypass-only
+2. Blockers: concrete open issues
+3. Verification: executed checks and result
+4. Review status: open or resolved conversations
+5. Next action: smallest meaningful next step
+
+## Escalation
+
+If approval is not technically or procedurally defensible:
+
+- name the reason directly
+- do not fall back to vague wording
+- do not recommend merge against the objective status
+
+## Success Condition
+
+The task is successfully completed when it is clear:
+
+- whether the change is merge-ready
+- which blockers, if any, are still open
+- which local verification actually took place
+- whether a bypass is excluded, unnecessary, or requires explicit justification

--- a/.github/prompts/pr-operations-governance.prompt.md
+++ b/.github/prompts/pr-operations-governance.prompt.md
@@ -1,0 +1,110 @@
+---
+description: Evaluates operational PR readiness including local checks, open reviews, branch protection, and tightly scoped bypass exceptions.
+---
+
+# PR Operations Governance Prompt
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before execution when it is not empty.
+
+## Task
+
+Assess the operational readiness of a pull request or a specific change.
+
+Do not stay in plan-only mode once the request can be validated locally. Work in execution mode.
+
+## Goal
+
+Provide a defensible conclusion covering:
+
+- whether the change is merge-ready
+- which blockers are still open
+- which local checks were actually executed
+- whether review or branch-protection requirements are still missing
+- whether a bypass is excluded, unnecessary, or only defensible as a justified exception
+
+## Required Flow
+
+1. Determine the affected change scope.
+2. Identify the smallest meaningful local validation.
+3. Check open review comments and unresolved PR conversations.
+4. Compare the status against branch-protection requirements.
+5. Only then summarize the readiness status.
+
+## Local Checks
+
+Use this priority order:
+
+1. focused tests for the affected scope
+2. focused lint or typecheck for the affected scope
+3. relevant build or runtime check
+4. broader project checks only when the narrower check is insufficient
+
+If checks cannot be executed, document:
+
+- which check is missing
+- why it could not be run
+- which risk remains open because of that gap
+
+## Review And Conversation Rules
+
+Before recommending merge:
+
+- treat open PR conversations as blockers until they are answered, implemented, or explicitly dismissed
+- distinguish informational comments from true merge blockers
+- fix locally verifiable defects directly when that is within the current assignment
+
+## Branch Protection
+
+Only declare a change merge-ready when the objective protection requirements are satisfied.
+
+At minimum, when enabled in the repository, this includes:
+
+- required status checks
+- required reviews
+- no blocking open conversations
+- no other protected merge blockers
+
+If anything is missing, name the exact missing condition.
+
+## Bypass Rule
+
+A bypass is only acceptable as a documented exception.
+
+Only consider it when:
+
+1. there is a concrete exception reason
+2. the bypassed protection requirements are explicitly named
+3. the residual risk is described briefly
+4. a responsible approval role can be named
+5. mandatory follow-up work is defined
+
+If a bypass is being considered, always document:
+
+- exception reason
+- bypassed protection rule
+- risk
+- approving role or person
+- mandatory follow-up work
+
+## Output Format
+
+Respond concisely and operationally with exactly these points:
+
+1. Status: merge-ready, not merge-ready, or bypass-only
+2. Blockers: concrete open issues
+3. Verification: executed checks and results
+4. Review status: open or resolved conversations
+5. Next action: smallest meaningful next step
+
+## Do Not
+
+- ignore open review threads
+- downplay branch protection
+- present a bypass as a standard path
+- run broad checklists before focused verification without need <!-- EOF -->

--- a/.github/prompts/pr-operations-governance.prompt.md
+++ b/.github/prompts/pr-operations-governance.prompt.md
@@ -107,4 +107,6 @@ Respond concisely and operationally with exactly these points:
 - ignore open review threads
 - downplay branch protection
 - present a bypass as a standard path
-- run broad checklists before focused verification without need <!-- EOF -->
+- run broad checklists before focused verification without need
+
+<!-- EOF -->

--- a/.github/skills/pr-operations-governance/SKILL.md
+++ b/.github/skills/pr-operations-governance/SKILL.md
@@ -1,0 +1,115 @@
+# PR Operations Governance
+
+Use this skill when operational pull request execution needs to be prepared, assessed, or safeguarded.
+
+## Purpose
+
+This skill consolidates the rules for:
+
+- local checks before a PR recommendation or merge decision
+- review handling and open PR conversations
+- branch-protection requirements
+- bypass approvals as tightly scoped exceptions
+
+## When To Apply This Skill
+
+Use this skill when at least one of the following is true:
+
+- a change needs to be made merge-ready
+- an open PR still has unanswered or unresolved review comments
+- local verification is required before CI or before merge
+- branch protection is blocking merge
+- a bypass approval is being discussed or documented
+
+## Operational Mode
+
+Work in execution mode by default, not in plan-only mode.
+
+- Execute concrete checks and changes directly when the assignment is clear.
+- Hold back questions unless additional information is required for a safe decision.
+- Do not rely on a formal planning phase when operational execution is already authorized.
+
+## Local Checks
+
+Before recommending merge or review readiness:
+
+1. Identify the smallest meaningful validation for the affected scope.
+2. Run focused checks first, such as relevant tests, lint, or typecheck.
+3. Expand scope only when the focused check requires it.
+4. Record briefly what was executed and what could not be executed.
+
+Check priority:
+
+1. Affected tests
+2. Affected lint or typecheck scope
+3. Relevant build or runtime check
+4. Broader project checks only after that
+
+## Reviews And Open PR Conversations
+
+Before recommending merge:
+
+1. Check whether open review comments or unanswered conversations exist.
+2. Treat unresolved threads as blockers until they are explicitly answered or dismissed.
+3. Distinguish between informational comments and merge-blocking issues.
+4. Summarize the remaining status precisely: open, answered, implemented, or intentionally deferred.
+
+When review feedback exists:
+
+- fix concrete defects directly when possible
+- do not answer with intent alone when a change can be made
+- call out risks that remain without a code change
+
+## Branch Protection
+
+Branch protection is the default, not an optional process step.
+
+Pay attention in particular to:
+
+- required status checks
+- required reviews
+- blocking conversations
+- linear-history or otherwise protected merge requirements in the repository
+
+Recommendation:
+
+- Do not state that a PR is ready when branch protection is still objectively unmet.
+- Instead, name the exact missing condition.
+
+## Bypass Approval
+
+A bypass is only acceptable as an explicit exception.
+
+A bypass should only be recommended or documented when all of the following are true:
+
+1. The reason is concrete and time-sensitive.
+2. The residual risk is named.
+3. The unmet standard conditions are listed explicitly.
+4. A responsible approval authority is identified.
+5. Follow-up obligations are defined.
+
+Minimum documentation for a bypass:
+
+- affected PR or branch
+- specific protection rule being bypassed
+- reason for the exception
+- risk assessment
+- approving person or role
+- required follow-up work with ownership
+
+## Expected Output
+
+When applying this skill, provide a concise operational assessment with:
+
+1. current merge status
+2. open blockers
+3. checks already executed
+4. missing checks or unresolved conversations
+5. bypass need only when standard approval is not reachable
+
+## Do Not
+
+- downplay branch protection implicitly
+- ignore open review threads
+- present a bypass as the normal path
+- run broad checklists when a narrower, reliable check is enough

--- a/.github/workflows/qodo-pr-agent.yml
+++ b/.github/workflows/qodo-pr-agent.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   pr_agent_job:
+    concurrency:
+      group: qodo-pr-agent-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+      cancel-in-progress: true
     if: ${{ github.event.sender.type != 'Bot' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request) }}
     runs-on: ubuntu-latest
     permissions:
@@ -32,11 +35,12 @@ jobs:
           github_action_config.auto_update_changelog: 'false'
           github_action_config.auto_questions: 'false'
           # Configure which PR events trigger the action
-          github_action_config.pr_actions: '["opened", "reopened", "synchronize", "ready_for_review", "review_requested"]'
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'
           # Custom review instructions for TypeScript/Next.js project
           pr_reviewer.extra_instructions: 'Focus on TypeScript best practices, Next.js 15.5.6 App Router patterns, React 18 hooks usage, Prisma ORM queries, Material-UI components, security vulnerabilities, and performance issues. Check for proper error handling, async/await patterns, and adherence to project constitution requirements.'
           # Language-specific settings for TypeScript
           pr_code_suggestions.num_code_suggestions: '6'
+          pr_code_suggestions.persistent_comment: 'true'
           pr_code_suggestions.suggestions_score_threshold: '7'
           # Performance optimization for the repository
           config.large_patch_policy: 'clip'

--- a/.github/workflows/qodo-pr-agent.yml
+++ b/.github/workflows/qodo-pr-agent.yml
@@ -22,9 +22,10 @@ jobs:
       contents: write
     name: Run PR Agent on every pull request, respond to user comments
     steps:
+      # qodo-ai/pr-agent v0.34 pinned to an immutable commit SHA.
       - name: PR Agent action step
         id: pragent
-        uses: qodo-ai/pr-agent@v0.34
+        uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/qodo-pr-agent.yml
+++ b/.github/workflows/qodo-pr-agent.yml
@@ -1,13 +1,17 @@
 name: 'Bot: Qodo PR Agent'
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
   issue_comment:
     types: [created]
 
 jobs:
   pr_agent_job:
-    if: ${{ github.event.sender.type != 'Bot' && (github.event_name == 'pull_request' || github.event.issue.pull_request) }}
+    if: ${{ github.event.sender.type != 'Bot' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request) }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -28,7 +32,7 @@ jobs:
           github_action_config.auto_update_changelog: 'false'
           github_action_config.auto_questions: 'false'
           # Configure which PR events trigger the action
-          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'
+          github_action_config.pr_actions: '["opened", "reopened", "synchronize", "ready_for_review", "review_requested"]'
           # Custom review instructions for TypeScript/Next.js project
           pr_reviewer.extra_instructions: 'Focus on TypeScript best practices, Next.js 15.5.6 App Router patterns, React 18 hooks usage, Prisma ORM queries, Material-UI components, security vulnerabilities, and performance issues. Check for proper error handling, async/await patterns, and adherence to project constitution requirements.'
           # Language-specific settings for TypeScript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,12 @@ npm run db:migrate # Prisma migrations against local env
 - **Branch naming**: Align with spec IDs (`021-learning-path`, etc.) and delete merged branches per
   `docs/ops/branch-hygiene.md` after production deploy.
 
+## PR Governance Automation
+
+- PR governance skill: `.github/skills/pr-operations-governance/SKILL.md`
+- PR governance agent: `.github/agents/pr-operations-governance.agent.md`
+- PR governance prompt: `.github/prompts/pr-operations-governance.prompt.md`
+
 ---
 
 ## 🎯 Repository Overview
@@ -133,19 +139,17 @@ hemera/
 
 ### Key Files to Know
 
-| File | Purpose | When You'd Touch It |
-|------|---------|---------------------|
-| `app/page.tsx` | Landing page fetching featured courses | Update marketing hero or data mapping |
-| `app/api/health/route.ts` | Health endpoint exposing build/version metadata | Monitor uptime probes or add diagnostics |
-| `lib/api/courses.ts` | Server-side course data access helpers | Modify fetching, availability, curriculum logic |
-| `lib/db/prisma.ts` | Prisma client factory (Accelerate vs pg adapter) | Adjust DB connection strategy or close hooks |
-| `lib/env.ts` | Centralized env schema/validation | Add new env vars or tighten validation |
-| `prisma/schema.prisma` | Data model + relations | Introduce fields/entities before running migrations |
-| `scripts/deploy-migrations.mjs` | Build gate ensuring DB migrations are applied | Update migration rollout before `npm run build` |
-| `tests/setup.ts` | Jest global hooks (DB cleanup, env toggles) | Extend test fixtures or teardown logic |
-| `playwright.config.ts` | E2E runner config (workers, retries, env) | Calibrate E2E reliability or base URL |
-| `docs/ops/branch-hygiene.md` | Branch cleanup process | Reference after merges/deploys |
-| `README.md` | Specs-first workflow + ops guardrails | Onboard newcomers or adjust workflow narrative |
+- `app/page.tsx`: Landing page fetching featured courses. Touch when updating the marketing hero or featured course mapping.
+- `app/api/health/route.ts`: Health endpoint exposing build and version metadata. Touch when extending uptime diagnostics.
+- `lib/api/courses.ts`: Server-side course data access helpers. Touch when changing fetching, availability, or curriculum logic.
+- `lib/db/prisma.ts`: Prisma client factory for Accelerate versus pg adapter flows. Touch when adjusting connection strategy or shutdown behavior.
+- `lib/env.ts`: Centralized environment schema and validation. Touch when adding or tightening env configuration.
+- `prisma/schema.prisma`: Data model and relations. Touch when introducing entities or fields before migrations.
+- `scripts/deploy-migrations.mjs`: Build gate for unapplied migrations. Touch when rollout behavior before `npm run build` changes.
+- `tests/setup.ts`: Jest global hooks for DB cleanup and env toggles. Touch when extending fixtures or teardown behavior.
+- `playwright.config.ts`: E2E runner configuration for workers, retries, and environment wiring. Touch when calibrating E2E reliability or base URL.
+- `docs/ops/branch-hygiene.md`: Branch cleanup process. Touch when merge and cleanup workflow guidance changes.
+- `README.md`: Specs-first workflow and ops guardrails. Touch when onboarding or workflow guidance changes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Run `nvm use` to switch to the correct Node version automatically.
 
 See `.github/prompts/*.prompt.md` and `.specify/templates/*` for automation guidance.
 
+PR governance assets are available here:
+
+- Skill: `.github/skills/pr-operations-governance/SKILL.md`
+- Agent: `.github/agents/pr-operations-governance.agent.md`
+- Prompt: `.github/prompts/pr-operations-governance.prompt.md`
+
 ## Quality Gates (Docs)
 
 Automated checks run on pull requests and on main:
@@ -116,10 +122,10 @@ LOOPS_API_KEY=loops_xxxxx  # Get from Loops.so Dashboard → API
 
 Create the following templates in your Loops.so dashboard:
 
-| Template ID | Purpose | Variables |
-|-------------|---------|-----------|
-| `prerequisite-review` | Admin notification for PRE_BOOKED booking | `customerName`, `courseTitle`, `adminUrl` |
-| `booking-rejected` | Customer rejection notice | `firstName`, `courseTitle` |
+| Template ID            | Purpose                                      | Variables                                 |
+| ---------------------- | -------------------------------------------- | ----------------------------------------- |
+| `prerequisite-review`  | Admin notification for PRE_BOOKED booking    | `customerName`, `courseTitle`, `adminUrl` |
+| `booking-rejected`     | Customer rejection notice                    | `firstName`, `courseTitle`                |
 
 ### Feature Behavior
 


### PR DESCRIPTION
## Summary

Add PR governance automation assets and wire them into the repository workflow/documentation.

- add PR governance skill, agent, and prompt assets under `.github/`
- document the new PR governance automation entry points in `README.md` and `AGENTS.md`
- normalize affected markdown formatting in the touched documentation
- tighten the Qodo PR Agent workflow to avoid duplicate runs and pin the action to an immutable SHA

Related specs:
- none

## Checklist

- [ ] Quality Gates (lint, typecheck, build, tests) pass locally
- [ ] Live monitoring of Deploy workflow performed (Preview/Production) and status confirmed
- [ ] Deployment URL captured and artifacts (e.g., Playwright report) reviewed if present
- [x] Branch hygiene executed or scheduled (branch cleanup after successful merge/deploy)
- [x] Docs updated (README / Runbooks) if behavior changed

Current validation completed in this PR:
- [x] Markdown lint for touched docs/prompt files
- [x] YAML syntax parse for `.github/workflows/qodo-pr-agent.yml`
- [x] Open Copilot and CodeRabbit review threads addressed and resolved
- [ ] CI rerun after latest workflow commits is still in progress

## Screenshots / Links

- Deployment URL: pending latest push / GitHub checks rerun
- Playwright report (if any): not applicable
- Related specs: none

## Breaking Changes

- [x] No
- [ ] Yes – Migration/Manual steps required

## Risk / Rollback

Risk is low and limited to documentation plus PR automation workflow behavior. If the updated Qodo workflow causes unexpected behavior, revert the workflow-only commits to restore the previous trigger/action configuration.

## Additional Notes

Latest PR-specific validation and follow-up work:
- `npx markdownlint-cli ".github/skills/pr-operations-governance/SKILL.md" ".github/agents/pr-operations-governance.agent.md" ".github/prompts/pr-operations-governance.prompt.md" "AGENTS.md" "README.md" --config .markdownlintrc`
- Ruby YAML parse of `.github/workflows/qodo-pr-agent.yml`
- latest commits: `89939f4` and `cf958b8`
- remaining gate for merge readiness is the completion of the currently rerunning GitHub checks