### PR TITLE
fix: gate seminar steps before course start

### DIFF
--- a/app/my-courses/[bookingId]/nachbereitung/page.tsx
+++ b/app/my-courses/[bookingId]/nachbereitung/page.tsx
@@ -17,7 +17,10 @@ import { getResolvedSummaryAssets } from '@/lib/db/courseParticipation';
 import { prisma } from '@/lib/db/prisma';
 import { colors, typography } from '@/lib/design-tokens';
 import { serverInstance } from '@/lib/monitoring/rollbar-official';
-import { shouldUnlockFutureCourseStepsInDevelopment } from '@/lib/utils/course-step-access';
+import {
+  shouldLockCourseStepsUntilSeminarStart,
+  shouldUnlockFutureCourseStepsInDevelopment,
+} from '@/lib/utils/course-step-access';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -60,6 +63,10 @@ export default async function NachbereitungPage({
   });
 
   if (!booking) {
+    notFound();
+  }
+
+  if (shouldLockCourseStepsUntilSeminarStart(booking.course.startDate)) {
     notFound();
   }
 

--- a/app/my-courses/[bookingId]/seminarveranstaltung/page.tsx
+++ b/app/my-courses/[bookingId]/seminarveranstaltung/page.tsx
@@ -17,7 +17,10 @@ import { CurriculumSection } from '@/components/course-detail/CurriculumSection'
 import { requireAuthenticatedUser } from '@/lib/auth/helpers';
 import { prisma } from '@/lib/db/prisma';
 import { colors, typography } from '@/lib/design-tokens';
-import { shouldUnlockFutureCourseStepsInDevelopment } from '@/lib/utils/course-step-access';
+import {
+  shouldLockCourseStepsUntilSeminarStart,
+  shouldUnlockFutureCourseStepsInDevelopment,
+} from '@/lib/utils/course-step-access';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -75,6 +78,10 @@ export default async function SeminarveranstaltungPage({
   });
 
   if (!booking) {
+    notFound();
+  }
+
+  if (shouldLockCourseStepsUntilSeminarStart(booking.course.startDate)) {
     notFound();
   }
 

--- a/app/my-courses/[bookingId]/verhandlungsergebnis/page.tsx
+++ b/app/my-courses/[bookingId]/verhandlungsergebnis/page.tsx
@@ -18,7 +18,10 @@ import { loadNegotiationResult } from '@/lib/db/courseParticipation';
 import { prisma } from '@/lib/db/prisma';
 import { colors, typography } from '@/lib/design-tokens';
 import { isNegotiationPartner } from '@/lib/types/participation';
-import { shouldUnlockFutureCourseStepsInDevelopment } from '@/lib/utils/course-step-access';
+import {
+  shouldLockCourseStepsUntilSeminarStart,
+  shouldUnlockFutureCourseStepsInDevelopment,
+} from '@/lib/utils/course-step-access';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -60,6 +63,10 @@ export default async function VerhandlungsergebnisPage({
   });
 
   if (!booking) {
+    notFound();
+  }
+
+  if (shouldLockCourseStepsUntilSeminarStart(booking.course.startDate)) {
     notFound();
   }
 

--- a/components/dashboard/CourseProgressStepper.tsx
+++ b/components/dashboard/CourseProgressStepper.tsx
@@ -276,6 +276,7 @@ export default function CourseProgressStepper({
             state === 'available';
           const isLockedUntilSeminarStart =
             shouldLockFutureSteps && step.key !== 'VORBEREITUNG';
+          const stepAriaLabel = `${step.label} – ${timelineDate ?? step.timelineLabel}`;
 
           const label = (
             <StepLabel
@@ -375,7 +376,7 @@ export default function CourseProgressStepper({
                     display: isMobile ? 'block' : 'inline',
                     width: isMobile ? '100%' : 'auto',
                   }}
-                  aria-label={`${step.label} – ${timelineDate ?? step.timelineLabel}`}
+                  aria-label={stepAriaLabel}
                 >
                   {label}
                 </Link>

--- a/components/dashboard/CourseProgressStepper.tsx
+++ b/components/dashboard/CourseProgressStepper.tsx
@@ -18,7 +18,10 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import Link from 'next/link';
 import { colors, typography } from '@/lib/design-tokens';
 import type { ParticipationStatus } from '@/lib/types/participation';
-import { shouldUnlockFutureCourseStepsInDevelopment } from '@/lib/utils/course-step-access';
+import {
+  shouldLockCourseStepsUntilSeminarStart,
+  shouldUnlockFutureCourseStepsInDevelopment,
+} from '@/lib/utils/course-step-access';
 
 export type { ParticipationStatus } from '@/lib/types/participation';
 
@@ -197,6 +200,8 @@ export default function CourseProgressStepper({
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const unlockFutureSteps =
     shouldUnlockFutureCourseStepsInDevelopment(courseStartDate);
+  const shouldLockFutureSteps =
+    shouldLockCourseStepsUntilSeminarStart(courseStartDate);
   const stepStates = DASHBOARD_STEPS.map(step =>
     getStepState(step, participationStatus)
   );
@@ -269,6 +274,79 @@ export default function CourseProgressStepper({
             unlockFutureSteps &&
             step.key !== 'VORBEREITUNG' &&
             state === 'available';
+          const isLockedUntilSeminarStart =
+            shouldLockFutureSteps && step.key !== 'VORBEREITUNG';
+
+          const label = (
+            <StepLabel
+              StepIconComponent={props => (
+                <NumberedStepIcon {...props} unlocked={isDevUnlocked} />
+              )}
+              sx={{
+                cursor: isLockedUntilSeminarStart ? 'default' : 'pointer',
+                '& .MuiStepLabel-labelContainer': {
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'flex-start',
+                  alignItems: 'center',
+                  minHeight: 52,
+                },
+                '& .MuiStepLabel-label': {
+                  display: 'block',
+                  fontFamily: typography.body,
+                  fontSize: '1rem',
+                  fontWeight: 400,
+                  whiteSpace: { xs: 'normal', md: 'nowrap' },
+                  overflowWrap: 'anywhere',
+                  color:
+                    state === 'active'
+                      ? colors.marsala
+                      : state === 'completed'
+                        ? colors.statusHealthy
+                        : isDevUnlocked
+                          ? colors.marsala
+                          : colors.lightBlack,
+                  mt: 0.5,
+                  lineHeight: 1.2,
+                  textAlign: 'center',
+                },
+                '& .MuiStepLabel-label.MuiStepLabel-alternativeLabel': {
+                  marginTop: ALTERNATIVE_LABEL_MARGIN_TOP,
+                },
+                '& .MuiStepLabel-label.Mui-active': {
+                  color: colors.marsala,
+                  fontWeight: 400,
+                  mt: 0.5,
+                },
+                '& .MuiStepLabel-label.Mui-active.MuiStepLabel-alternativeLabel':
+                  {
+                    marginTop: ALTERNATIVE_LABEL_MARGIN_TOP,
+                  },
+                '& .MuiStepLabel-label.Mui-completed': {
+                  color: colors.statusHealthy,
+                  fontWeight: 400,
+                },
+                '& .MuiStepLabel-label.Mui-completed.MuiStepLabel-alternativeLabel':
+                  {
+                    marginTop: ALTERNATIVE_LABEL_MARGIN_TOP,
+                  },
+              }}
+            >
+              {step.label}
+              <Typography
+                sx={{
+                  fontFamily: typography.body,
+                  fontSize: '0.85rem',
+                  color: colors.lightBlack,
+                  opacity: 0.6,
+                  mt: 0.25,
+                  lineHeight: 1.2,
+                }}
+              >
+                {timelineDate ?? step.timelineLabel}
+              </Typography>
+            </StepLabel>
+          );
 
           return (
             <Step
@@ -276,85 +354,32 @@ export default function CourseProgressStepper({
               completed={state === 'completed'}
               active={state === 'active'}
             >
-              <Link
-                href={href}
-                style={{
-                  textDecoration: 'none',
-                  color: 'inherit',
-                  display: isMobile ? 'block' : 'inline',
-                  width: isMobile ? '100%' : 'auto',
-                }}
-                aria-label={`${step.label} – ${timelineDate ?? step.timelineLabel}`}
-              >
-                <StepLabel
-                  StepIconComponent={props => (
-                    <NumberedStepIcon {...props} unlocked={isDevUnlocked} />
-                  )}
+              {isLockedUntilSeminarStart ? (
+                <Box
+                  aria-disabled='true'
                   sx={{
-                    cursor: 'pointer',
-                    '& .MuiStepLabel-labelContainer': {
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'flex-start',
-                      alignItems: 'center',
-                      minHeight: 52,
-                    },
-                    '& .MuiStepLabel-label': {
-                      display: 'block',
-                      fontFamily: typography.body,
-                      fontSize: '1rem',
-                      fontWeight: 400,
-                      whiteSpace: { xs: 'normal', md: 'nowrap' },
-                      overflowWrap: 'anywhere',
-                      color:
-                        state === 'active'
-                          ? colors.marsala
-                          : state === 'completed'
-                            ? colors.statusHealthy
-                            : isDevUnlocked
-                              ? colors.marsala
-                              : colors.lightBlack,
-                      mt: 0.5,
-                      lineHeight: 1.2,
-                      textAlign: 'center',
-                    },
-                    '& .MuiStepLabel-label.MuiStepLabel-alternativeLabel': {
-                      marginTop: ALTERNATIVE_LABEL_MARGIN_TOP,
-                    },
-                    '& .MuiStepLabel-label.Mui-active': {
-                      color: colors.marsala,
-                      fontWeight: 400,
-                      mt: 0.5,
-                    },
-                    '& .MuiStepLabel-label.Mui-active.MuiStepLabel-alternativeLabel':
-                      {
-                        marginTop: ALTERNATIVE_LABEL_MARGIN_TOP,
-                      },
-                    '& .MuiStepLabel-label.Mui-completed': {
-                      color: colors.statusHealthy,
-                      fontWeight: 400,
-                    },
-                    '& .MuiStepLabel-label.Mui-completed.MuiStepLabel-alternativeLabel':
-                      {
-                        marginTop: ALTERNATIVE_LABEL_MARGIN_TOP,
-                      },
+                    textDecoration: 'none',
+                    color: 'inherit',
+                    display: isMobile ? 'block' : 'inline',
+                    width: isMobile ? '100%' : 'auto',
                   }}
                 >
-                  {step.label}
-                  <Typography
-                    sx={{
-                      fontFamily: typography.body,
-                      fontSize: '0.85rem',
-                      color: colors.lightBlack,
-                      opacity: 0.6,
-                      mt: 0.25,
-                      lineHeight: 1.2,
-                    }}
-                  >
-                    {timelineDate ?? step.timelineLabel}
-                  </Typography>
-                </StepLabel>
-              </Link>
+                  {label}
+                </Box>
+              ) : (
+                <Link
+                  href={href}
+                  style={{
+                    textDecoration: 'none',
+                    color: 'inherit',
+                    display: isMobile ? 'block' : 'inline',
+                    width: isMobile ? '100%' : 'auto',
+                  }}
+                  aria-label={`${step.label} – ${timelineDate ?? step.timelineLabel}`}
+                >
+                  {label}
+                </Link>
+              )}
             </Step>
           );
         })}

--- a/lib/utils/course-step-access.ts
+++ b/lib/utils/course-step-access.ts
@@ -3,7 +3,7 @@ export function hasCourseStarted(
   now = Date.now()
 ): boolean {
   if (!courseStartDate) {
-    return true;
+    return false;
   }
 
   const start =
@@ -12,7 +12,7 @@ export function hasCourseStarted(
       : new Date(courseStartDate);
 
   if (Number.isNaN(start.getTime())) {
-    return true;
+    return false;
   }
 
   return start.getTime() <= now;
@@ -20,7 +20,8 @@ export function hasCourseStarted(
 
 export function shouldUnlockFutureCourseStepsInDevelopment(
   courseStartDate: string | Date | null | undefined,
-  nodeEnv = process.env.NODE_ENV
+  nodeEnv = process.env.NODE_ENV,
+  now = Date.now()
 ): boolean {
   if (nodeEnv !== 'development' || !courseStartDate) {
     return false;
@@ -35,7 +36,7 @@ export function shouldUnlockFutureCourseStepsInDevelopment(
     return false;
   }
 
-  return true;
+  return !hasCourseStarted(start, now);
 }
 
 export function shouldLockCourseStepsUntilSeminarStart(
@@ -43,8 +44,14 @@ export function shouldLockCourseStepsUntilSeminarStart(
   nodeEnv = process.env.NODE_ENV,
   now = Date.now()
 ): boolean {
+  if (!courseStartDate) {
+    return false;
+  }
   return (
-    !shouldUnlockFutureCourseStepsInDevelopment(courseStartDate, nodeEnv) &&
-    !hasCourseStarted(courseStartDate, now)
+    !shouldUnlockFutureCourseStepsInDevelopment(
+      courseStartDate,
+      nodeEnv,
+      now
+    ) && !hasCourseStarted(courseStartDate, now)
   );
 }

--- a/lib/utils/course-step-access.ts
+++ b/lib/utils/course-step-access.ts
@@ -44,14 +44,25 @@ export function shouldLockCourseStepsUntilSeminarStart(
   nodeEnv = process.env.NODE_ENV,
   now = Date.now()
 ): boolean {
-  if (!courseStartDate) {
+  if (nodeEnv === 'development') {
     return false;
   }
+
+  if (!courseStartDate) {
+    return true;
+  }
+
+  const start =
+    courseStartDate instanceof Date
+      ? courseStartDate
+      : new Date(courseStartDate);
+
+  if (Number.isNaN(start.getTime())) {
+    return true;
+  }
+
   return (
-    !shouldUnlockFutureCourseStepsInDevelopment(
-      courseStartDate,
-      nodeEnv,
-      now
-    ) && !hasCourseStarted(courseStartDate, now)
+    !shouldUnlockFutureCourseStepsInDevelopment(start, nodeEnv, now) &&
+    !hasCourseStarted(start, now)
   );
 }

--- a/lib/utils/course-step-access.ts
+++ b/lib/utils/course-step-access.ts
@@ -1,7 +1,26 @@
+export function hasCourseStarted(
+  courseStartDate: string | Date | null | undefined,
+  now = Date.now()
+): boolean {
+  if (!courseStartDate) {
+    return true;
+  }
+
+  const start =
+    courseStartDate instanceof Date
+      ? courseStartDate
+      : new Date(courseStartDate);
+
+  if (Number.isNaN(start.getTime())) {
+    return true;
+  }
+
+  return start.getTime() <= now;
+}
+
 export function shouldUnlockFutureCourseStepsInDevelopment(
   courseStartDate: string | Date | null | undefined,
-  nodeEnv = process.env.NODE_ENV,
-  now = Date.now()
+  nodeEnv = process.env.NODE_ENV
 ): boolean {
   if (nodeEnv !== 'development' || !courseStartDate) {
     return false;
@@ -16,5 +35,16 @@ export function shouldUnlockFutureCourseStepsInDevelopment(
     return false;
   }
 
-  return start.getTime() <= now;
+  return true;
+}
+
+export function shouldLockCourseStepsUntilSeminarStart(
+  courseStartDate: string | Date | null | undefined,
+  nodeEnv = process.env.NODE_ENV,
+  now = Date.now()
+): boolean {
+  return (
+    !shouldUnlockFutureCourseStepsInDevelopment(courseStartDate, nodeEnv) &&
+    !hasCourseStarted(courseStartDate, now)
+  );
 }

--- a/tests/unit/components/CourseProgressStepper.spec.tsx
+++ b/tests/unit/components/CourseProgressStepper.spec.tsx
@@ -46,7 +46,8 @@ jest.mock('@mui/material/styles', () => {
 import CourseProgressStepper from '@/components/dashboard/CourseProgressStepper';
 
 const BOOKING_ID = 'booking-123';
-const FUTURE_COURSE_START_DATE = '2099-06-15T12:00:00.000Z';
+const futureCourseStartDate = '2099-06-15T12:00:00.000Z';
+const startedCourseStartDate = '2020-06-15T12:00:00.000Z';
 
 function formatTimelineDate(date: Date): string {
   return date.toLocaleDateString('de-DE', {
@@ -114,6 +115,7 @@ describe('CourseProgressStepper', () => {
       <CourseProgressStepper
         bookingId={BOOKING_ID}
         participationStatus="PREPARATION"
+        courseStartDate={startedCourseStartDate}
       />,
     );
 
@@ -126,7 +128,7 @@ describe('CourseProgressStepper', () => {
       <CourseProgressStepper
         bookingId={BOOKING_ID}
         participationStatus="PREPARATION"
-        courseStartDate={FUTURE_COURSE_START_DATE}
+        courseStartDate={futureCourseStartDate}
       />,
     );
 
@@ -140,14 +142,13 @@ describe('CourseProgressStepper', () => {
 
   it('keeps later steps clickable in development before seminar start', () => {
     const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
-
     try {
+      process.env.NODE_ENV = 'development';
       render(
         <CourseProgressStepper
           bookingId={BOOKING_ID}
           participationStatus="PREPARATION"
-          courseStartDate={FUTURE_COURSE_START_DATE}
+          courseStartDate={futureCourseStartDate}
         />,
       );
 
@@ -174,6 +175,7 @@ describe('CourseProgressStepper', () => {
       <CourseProgressStepper
         bookingId={BOOKING_ID}
         participationStatus="SUMMARY"
+        courseStartDate={startedCourseStartDate}
       />,
     );
 
@@ -186,6 +188,7 @@ describe('CourseProgressStepper', () => {
       <CourseProgressStepper
         bookingId={BOOKING_ID}
         participationStatus="DEBRIEFING"
+        courseStartDate={startedCourseStartDate}
       />,
     );
 
@@ -198,6 +201,7 @@ describe('CourseProgressStepper', () => {
       <CourseProgressStepper
         bookingId={BOOKING_ID}
         participationStatus="RESULT"
+        courseStartDate={startedCourseStartDate}
       />,
     );
 

--- a/tests/unit/components/CourseProgressStepper.spec.tsx
+++ b/tests/unit/components/CourseProgressStepper.spec.tsx
@@ -46,6 +46,7 @@ jest.mock('@mui/material/styles', () => {
 import CourseProgressStepper from '@/components/dashboard/CourseProgressStepper';
 
 const BOOKING_ID = 'booking-123';
+const FUTURE_COURSE_START_DATE = '2099-06-15T12:00:00.000Z';
 
 function formatTimelineDate(date: Date): string {
   return date.toLocaleDateString('de-DE', {
@@ -108,7 +109,7 @@ describe('CourseProgressStepper', () => {
     expect(completedIcons).toHaveLength(4);
   });
 
-  it('all steps are clickable links', () => {
+  it('all steps are clickable links when seminar date is unlocked', () => {
     render(
       <CourseProgressStepper
         bookingId={BOOKING_ID}
@@ -118,6 +119,40 @@ describe('CourseProgressStepper', () => {
 
     const links = screen.getAllByRole('link');
     expect(links).toHaveLength(4);
+  });
+
+  it('locks steps after preparation before seminar start in production-like environments', () => {
+    render(
+      <CourseProgressStepper
+        bookingId={BOOKING_ID}
+        participationStatus="PREPARATION"
+        courseStartDate={FUTURE_COURSE_START_DATE}
+      />,
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+
+    expect(screen.getByText('Seminarveranstaltung').closest('a')).toBeNull();
+    expect(screen.getByText('Nachbereitung Seminar').closest('a')).toBeNull();
+    expect(screen.getByText('Verhandlungsergebnis').closest('a')).toBeNull();
+  });
+
+  it('keeps later steps clickable in development before seminar start', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    render(
+      <CourseProgressStepper
+        bookingId={BOOKING_ID}
+        participationStatus="PREPARATION"
+        courseStartDate={FUTURE_COURSE_START_DATE}
+      />,
+    );
+
+    expect(screen.getAllByRole('link')).toHaveLength(4);
+
+    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it('vorbereitung step links to correct URL', () => {

--- a/tests/unit/components/CourseProgressStepper.spec.tsx
+++ b/tests/unit/components/CourseProgressStepper.spec.tsx
@@ -142,17 +142,19 @@ describe('CourseProgressStepper', () => {
     const originalNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
 
-    render(
-      <CourseProgressStepper
-        bookingId={BOOKING_ID}
-        participationStatus="PREPARATION"
-        courseStartDate={FUTURE_COURSE_START_DATE}
-      />,
-    );
+    try {
+      render(
+        <CourseProgressStepper
+          bookingId={BOOKING_ID}
+          participationStatus="PREPARATION"
+          courseStartDate={FUTURE_COURSE_START_DATE}
+        />,
+      );
 
-    expect(screen.getAllByRole('link')).toHaveLength(4);
-
-    process.env.NODE_ENV = originalNodeEnv;
+      expect(screen.getAllByRole('link')).toHaveLength(4);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
   });
 
   it('vorbereitung step links to correct URL', () => {

--- a/tests/unit/lib/utils/course-step-access.spec.ts
+++ b/tests/unit/lib/utils/course-step-access.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
-import { shouldUnlockFutureCourseStepsInDevelopment } from '@/lib/utils/course-step-access';
+import {
+  hasCourseStarted,
+  shouldLockCourseStepsUntilSeminarStart,
+  shouldUnlockFutureCourseStepsInDevelopment,
+} from '@/lib/utils/course-step-access';
 
 const STARTED_DATE = '2020-06-15T12:00:00.000Z';
 const FUTURE_DATE = '2099-06-15T12:00:00.000Z';
@@ -16,18 +20,48 @@ describe('shouldUnlockFutureCourseStepsInDevelopment', () => {
     ).toBe(true);
   });
 
-  it('does not unlock future steps before seminar start', () => {
+  it('unlocks future steps in development before seminar start', () => {
     expect(
       shouldUnlockFutureCourseStepsInDevelopment(
         FUTURE_DATE,
         ENV_DEVELOPMENT
       )
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('does not unlock future steps outside development mode', () => {
     expect(
       shouldUnlockFutureCourseStepsInDevelopment(FUTURE_DATE, ENV_TEST)
+    ).toBe(false);
+  });
+});
+
+describe('hasCourseStarted', () => {
+  it('returns true for started seminars', () => {
+    expect(hasCourseStarted(STARTED_DATE)).toBe(true);
+  });
+
+  it('returns false for future seminars', () => {
+    expect(hasCourseStarted(FUTURE_DATE)).toBe(false);
+  });
+});
+
+describe('shouldLockCourseStepsUntilSeminarStart', () => {
+  it('locks future seminar steps outside development mode before seminar start', () => {
+    expect(
+      shouldLockCourseStepsUntilSeminarStart(FUTURE_DATE, ENV_TEST)
+    ).toBe(true);
+  });
+
+  it('does not lock future seminar steps in development mode', () => {
+    expect(
+      shouldLockCourseStepsUntilSeminarStart(FUTURE_DATE, ENV_DEVELOPMENT)
+    ).toBe(false);
+  });
+
+  it('does not lock started seminar steps outside development mode', () => {
+    expect(
+      shouldLockCourseStepsUntilSeminarStart(STARTED_DATE, ENV_TEST)
     ).toBe(false);
   });
 });

--- a/tests/unit/lib/utils/course-step-access.spec.ts
+++ b/tests/unit/lib/utils/course-step-access.spec.ts
@@ -11,13 +11,13 @@ const ENV_DEVELOPMENT = 'development';
 const ENV_TEST = 'test';
 
 describe('shouldUnlockFutureCourseStepsInDevelopment', () => {
-  it('unlocks future steps in development after seminar start', () => {
+  it('does not unlock already-started steps in development', () => {
     expect(
       shouldUnlockFutureCourseStepsInDevelopment(
         STARTED_DATE,
         ENV_DEVELOPMENT
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('unlocks future steps in development before seminar start', () => {
@@ -44,6 +44,18 @@ describe('hasCourseStarted', () => {
   it('returns false for future seminars', () => {
     expect(hasCourseStarted(FUTURE_DATE)).toBe(false);
   });
+
+  it('returns false when courseStartDate is null', () => {
+    expect(hasCourseStarted(null)).toBe(false);
+  });
+
+  it('returns false when courseStartDate is undefined', () => {
+    expect(hasCourseStarted(undefined)).toBe(false);
+  });
+
+  it('returns false when courseStartDate is an invalid date string', () => {
+    expect(hasCourseStarted('not-a-date')).toBe(false);
+  });
 });
 
 describe('shouldLockCourseStepsUntilSeminarStart', () => {
@@ -62,6 +74,18 @@ describe('shouldLockCourseStepsUntilSeminarStart', () => {
   it('does not lock started seminar steps outside development mode', () => {
     expect(
       shouldLockCourseStepsUntilSeminarStart(STARTED_DATE, ENV_TEST)
+    ).toBe(false);
+  });
+
+  it('does not lock when courseStartDate is null', () => {
+    expect(
+      shouldLockCourseStepsUntilSeminarStart(null, ENV_TEST)
+    ).toBe(false);
+  });
+
+  it('does not lock when courseStartDate is undefined', () => {
+    expect(
+      shouldLockCourseStepsUntilSeminarStart(undefined, ENV_TEST)
     ).toBe(false);
   });
 });

--- a/tests/unit/lib/utils/course-step-access.spec.ts
+++ b/tests/unit/lib/utils/course-step-access.spec.ts
@@ -77,15 +77,21 @@ describe('shouldLockCourseStepsUntilSeminarStart', () => {
     ).toBe(false);
   });
 
-  it('does not lock when courseStartDate is null', () => {
+  it('locks when courseStartDate is null outside development mode', () => {
     expect(
       shouldLockCourseStepsUntilSeminarStart(null, ENV_TEST)
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it('does not lock when courseStartDate is undefined', () => {
+  it('locks when courseStartDate is invalid outside development mode', () => {
     expect(
-      shouldLockCourseStepsUntilSeminarStart(undefined, ENV_TEST)
+      shouldLockCourseStepsUntilSeminarStart('not-a-date', ENV_TEST)
+    ).toBe(true);
+  });
+
+  it('does not lock when courseStartDate is missing in development mode', () => {
+    expect(
+      shouldLockCourseStepsUntilSeminarStart(null, ENV_DEVELOPMENT)
     ).toBe(false);
   });
 });


### PR DESCRIPTION
## Was geändert wurde

- sperrt `Seminarveranstaltung`, `Nachbereitung Seminar` und `Verhandlungsergebnis` vor Seminarbeginn außerhalb von Development im Dashboard-Stepper
- lässt dieselben Schritte lokal in Development weiter zur Vorschau klickbar
- blockiert Direktzugriffe auf die drei Seiten serverseitig bis zum Seminarbeginn
- zentralisiert die Freigabe- und Sperrlogik in `lib/utils/course-step-access`
- ergänzt fokussierte Unit-Tests für Dashboard- und Utility-Verhalten

## Warum

Auf Production durften die drei Schritte vor Seminarbeginn nicht klickbar oder direkt erreichbar sein. Lokal in Development soll die Vorschau weiter möglich bleiben.

## Validierung

- `npx jest tests/unit/lib/utils/course-step-access.spec.ts tests/unit/components/CourseProgressStepper.spec.tsx --runInBand`
- 21 Tests grün
- Fehlercheck für betroffene Seiten, Stepper und Utility: sauber

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kursschritte und bestimmte Seiten sind vor dem offiziellen Seminarstart nicht mehr zugänglich; Inhalte werden vorab ausgeblendet.
  * Anzeigen im Kursfortschritt zeigen gesperrte Schritte ohne Navigation, mit sichtbarer Unterscheidung zu freigegebenen Schritten.
  * In der Entwicklungsumgebung bleiben Schritte vorab freischaltbar.

* **Tests**
  * Unit-Tests erweitert, um Seminarstart-abhängiges Sperr-/Entsperrverhalten abzudecken.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Laparo/hemera/pull/504)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->