### PR TITLE
fix: route X-API-Key service requests through proxy auth flow

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -74,21 +74,18 @@ export default function proxy(request: NextRequest, event: NextFetchEvent) {
       return NextResponse.next();
     }
 
-    // API-Key-basierte M2M-Authentifizierung: wenn ein X-API-Key Header
-    // vorhanden ist, Clerk-Middleware überspringen und den Request direkt
-    // durchlassen. Die Validierung erfolgt im Route-Handler.
-    const hasApiKey = !!request.headers.get('x-api-key');
-    if (hasApiKey) {
-      return NextResponse.next();
-    }
-
     // Fail fast if request has no usable auth material at all.
+    // Requests mit X-API-Key werden weiterhin durch die Clerk-Middleware
+    // geleitet, damit der normale API-Route-Resolver auf allen Umgebungen
+    // konsistent greift. Die eigentliche API-Key-Validierung erfolgt erst
+    // im Route-Handler.
+    const hasApiKey = !!request.headers.get('x-api-key');
     const authorizationHeader = request.headers.get('authorization');
     const bearerToken = extractBearerToken(authorizationHeader);
     const hasAuthHeader = !!bearerToken;
     const cookieValue = request.headers.get('cookie');
     const hasCookie = !!cookieValue && cookieValue.trim().length > 0;
-    if (!hasAuthHeader && !hasCookie) {
+    if (!hasApiKey && !hasAuthHeader && !hasCookie) {
       return new NextResponse(
         JSON.stringify({
           success: false,


### PR DESCRIPTION
## Summary
- remove the early `X-API-Key` bypass in `proxy.ts` for `/api/service/*`
- keep API-key requests on the normal proxy/auth path so the service route resolver is reached consistently
- retain fail-fast `401` responses only when no API key, bearer token, or cookie is present

## Validation
- validated locally against `http://localhost:3001/api/service/courses?limit=1`
- without `X-API-Key`: returns JSON `401`
- with `X-API-Key`: returns JSON `401` instead of HTML `404`
- verified that the remote instance still shows the old behavior until this change is deployed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Authentifizierungsvalidierung für API-Anfragen optimiert: X-API-Keys, Bearer-Tokens und Cookies werden nun einheitlich geprüft. Anfragen ohne valide Authentifizierungsmethode erhalten eine klare Fehlermeldung.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->