### PR TITLE
chore(tooling): track caveman-code prompt as versioned .example template

### DIFF
--- a/.github/prompts/caveman-code.prompt.md
+++ b/.github/prompts/caveman-code.prompt.md
@@ -3,7 +3,6 @@ name: caveman-code
 description: "Compressed coding assistant for this project. Use for debugging, code changes, repo questions, test guidance, and technical summaries with minimal prose but normal code formatting."
 argument-hint: "Task for caveman-code"
 agent: agent
-model: GPT-5 (copilot)
 ---
 
 The user input may be provided directly by chat or as an argument. Always use it.

--- a/.github/prompts/caveman-code.prompt.md.example
+++ b/.github/prompts/caveman-code.prompt.md.example
@@ -1,0 +1,56 @@
+---
+name: caveman-code
+description: "Compressed coding assistant for this project. Use for debugging, code changes, repo questions, test guidance, and technical summaries with minimal prose but normal code formatting."
+argument-hint: "Task for caveman-code"
+agent: agent
+model: GPT-5 (copilot)
+---
+
+The user input may be provided directly by chat or as an argument. Always use it.
+
+User input:
+
+$ARGUMENTS
+
+Caveman-code mode ON.
+
+Primary goal:
+- Minimum prose
+- Maximum signal
+- Keep code exact
+- Keep project conventions intact
+
+Response rules:
+- No filler
+- No politeness padding
+- No repeated restatement
+- Short sentences or fragments
+- Prefer keywords, bullets, arrows, and compact phrasing
+- Explain only what necessary
+- If user asks simple question: answer short
+- If user asks for fix: focus root cause, not broad theory
+- If uncertain: say unknown briefly
+
+Code rules:
+- Code blocks stay normal, valid, complete
+- Do not compress code syntax
+- Keep identifiers, types, imports, commands exact
+- Preserve readability in patches, code samples, and shell commands
+- Use normal formatting for code, JSON, YAML, SQL, and tests
+- File paths, symbols, commands: keep precise
+
+Project rules:
+- Respect repository instructions and existing code style
+- Keep user-facing German text informal
+- Prefer concise technical German outside code
+- For reviews: findings first, ordered by severity
+- For debugging: hypothesis -> check -> result
+- For implementation: shortest correct explanation, then concrete action
+
+Default output style:
+- Short
+- Direct
+- Technical
+- Useful
+
+If task needs detail, expand only where required.

--- a/.github/prompts/caveman-code.prompt.md.example
+++ b/.github/prompts/caveman-code.prompt.md.example
@@ -3,7 +3,6 @@ name: caveman-code
 description: "Compressed coding assistant for this project. Use for debugging, code changes, repo questions, test guidance, and technical summaries with minimal prose but normal code formatting."
 argument-hint: "Task for caveman-code"
 agent: agent
-model: GPT-5 (copilot)
 ---
 
 The user input may be provided directly by chat or as an argument. Always use it.

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ public/_next-video
 
 # VSCode AI-generated Codacy instructions (do not commit)
 .github/instructions/codacy.instructions.md
+
+# Local agent prompt assets (tracked template ships as .example)
+.github/prompts/caveman-code.prompt.md
+!/.github/prompts/caveman-code.prompt.md.example

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -11,3 +11,6 @@ out/
 # Test artifacts
 playwright-report/
 test-results/
+
+# Prompt templates (frontmatter + free form, not prose)
+.github/prompts/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Run `nvm use` to switch to the correct Node version automatically.
 
 See `.github/prompts/*.prompt.md` and `.specify/templates/*` for automation guidance.
 
+> Personal/agent-specific prompt assets (e.g. `caveman-code.prompt.md`) are
+> git-ignored. Restore them from the tracked `.example` template – see
+> [docs/ops/caveman-prompt.md](docs/ops/caveman-prompt.md).
+
 PR governance assets are available here:
 
 - Skill: `.github/skills/pr-operations-governance/SKILL.md`

--- a/docs/ops/caveman-prompt.md
+++ b/docs/ops/caveman-prompt.md
@@ -15,8 +15,10 @@ is a personal/agent-specific asset. A versioned template ships with the repo as
 cp .github/prompts/caveman-code.prompt.md.example \
    .github/prompts/caveman-code.prompt.md
 
-# Optional: pin to a different model
-$EDITOR .github/prompts/caveman-code.prompt.md   # adjust the `model:` field
+# Optional: pin to a specific model (VS Code Copilot model id, e.g. `gpt-4`)
+# Add or change the `model:` field in the YAML header if you want to override
+# the model picker. Without it, VS Code uses the currently selected model.
+$EDITOR .github/prompts/caveman-code.prompt.md
 ```
 
 The untracked `caveman-code.prompt.md` is covered by `.gitignore`, so it survives

--- a/docs/ops/caveman-prompt.md
+++ b/docs/ops/caveman-prompt.md
@@ -1,0 +1,38 @@
+# Caveman Code Prompt
+
+Compressed coding assistant for the hemera workspace. Lives under
+[`.github/prompts/`](../../.github/prompts/) so VS Code Copilot Chat can invoke
+it via `/caveman-code` (or by selecting it from the prompt picker).
+
+## Install (local only)
+
+The prompt is intentionally **not tracked** under `.github/prompts/` because it
+is a personal/agent-specific asset. A versioned template ships with the repo as
+[`.github/prompts/caveman-code.prompt.md.example`](../../.github/prompts/caveman-code.prompt.md.example).
+
+```bash
+# Restore from template after a clean checkout / `git clean`
+cp .github/prompts/caveman-code.prompt.md.example \
+   .github/prompts/caveman-code.prompt.md
+
+# Optional: pin to a different model
+$EDITOR .github/prompts/caveman-code.prompt.md   # adjust the `model:` field
+```
+
+The untracked `caveman-code.prompt.md` is covered by `.gitignore`, so it survives
+branches, merges and `git restore` without polluting commits.
+
+## Behavior
+
+- Minimum prose, maximum signal.
+- Code blocks stay normal, valid, complete – only prose is compressed.
+- User-facing text remains informal German (matches repo convention).
+- For reviews: findings first, ordered by severity.
+- For debugging: hypothesis → check → result.
+- For implementation: shortest correct explanation, then concrete action.
+
+## Updating the template
+
+1. Edit `.github/prompts/caveman-code.prompt.md.example`.
+2. Open a PR labelled `area: tooling`.
+3. Reference the change in `AGENTS.md` if it changes visible behavior.


### PR DESCRIPTION
## Summary

The `/caveman-code` chat prompt was introduced in #503 as a **local agent artifact** and therefore git-ignored. In practice this caused it to vanish after every clean checkout, branch switch, or `git restore`, breaking the prompt picker in VS Code.

This PR ships the prompt as a **tracked `.example` template** so the asset is version-controlled and recoverable, while keeping the personal copy local and git-ignored.

## Changes

| File | Purpose |
|------|---------|
| `.github/prompts/caveman-code.prompt.md.example` (new) | Canonical versioned template |
| `.gitignore` | Ignore personal copy `caveman-code.prompt.md`, allow `.example` via negation |
| `docs/ops/caveman-prompt.md` (new) | Restore flow + behavior docs |
| `README.md` | Workflow section link to the new ops doc |
| `.markdownlintignore` | Exclude `.github/prompts/` (frontmatter ≠ prose) |

## Restore after `git clean`

```bash
cp .github/prompts/caveman-code.prompt.md.example \
   .github/prompts/caveman-code.prompt.md
```

## Quality gates

- `cspell`: clean (lint-staged pre-commit)
- `markdownlint-cli2`: clean on `docs/ops/caveman-prompt.md`
- `biome check`: clean
- No TS code changes → `tsc` / `jest` not affected

## Notes

- Branch: `chore/caveman-prompt-template`
- Commit: `1050b3a`
- Duplicates under `app/.../page 2.tsx` and `app/api/.../route 2.ts` are unrelated leftovers from earlier sessions, intentionally left out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Dokumentation & Konfiguration

* **Documentation**
  * Neue Dokumentation für das „caveman-code"-Prompt-System hinzugefügt, einschließlich lokaler Setup-Anleitung.

* **Chores**
  * Konfigurationsdateien (.gitignore, .markdownlintignore) für Prompt-Verwaltung aktualisiert.
  * README um Hinweise zu persönlichen Prompt-Assets ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->