### PR TITLE
chore: add Playwright MCP server to workspace config

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -20,6 +20,11 @@
       "env": {
         "CODACY_ACCOUNT_TOKEN": "${input:codacy_token}"
       }
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
     }
   },
   "inputs": [


### PR DESCRIPTION
## Summary

Adds the Playwright MCP server (`@playwright/mcp`) to the workspace-level `.vscode/mcp.json` so it is visible and available in this workspace and project.

## Changes

- `.vscode/mcp.json`: new file registering the `playwright` MCP server via `npx @playwright/mcp@latest`.

## Why

Makes the Playwright MCP server discoverable and usable from VS Code's MCP tooling within this repository.