### PR TITLE
style: use block body for arrow functions in event handlers

### DIFF
--- a/app/admin/course-material/new/create-client.tsx
+++ b/app/admin/course-material/new/create-client.tsx
@@ -165,7 +165,9 @@ export default function CreateCourseMaterialClient() {
           <Box sx={{ mb: 2 }}>
             <Button
               size='small'
-              onClick={() => setSelectedMode(null)}
+              onClick={() => {
+                setSelectedMode(null);
+              }}
               startIcon={<ArrowBackIcon />}
             >
               Zurück zur Auswahl
@@ -180,7 +182,9 @@ export default function CreateCourseMaterialClient() {
           <Box sx={{ mb: 2 }}>
             <Button
               size='small'
-              onClick={() => setSelectedMode(null)}
+              onClick={() => {
+                setSelectedMode(null);
+              }}
               startIcon={<ArrowBackIcon />}
             >
               Zurück zur Auswahl
@@ -198,7 +202,9 @@ export default function CreateCourseMaterialClient() {
           <Box sx={{ mb: 2 }}>
             <Button
               size='small'
-              onClick={() => setSelectedMode(null)}
+              onClick={() => {
+                setSelectedMode(null);
+              }}
               startIcon={<ArrowBackIcon />}
             >
               Zurück zur Auswahl

--- a/components/admin/HTMLContentUploadForm.tsx
+++ b/components/admin/HTMLContentUploadForm.tsx
@@ -129,7 +129,9 @@ export default function HTMLContentUploadForm({
       <TextField
         label='Identifier (optional)'
         value={identifier}
-        onChange={e => setIdentifier(e.target.value)}
+        onChange={e => {
+          setIdentifier(e.target.value);
+        }}
         fullWidth
         helperText='Wird automatisch aus dem Titel generiert, falls leer gelassen'
         sx={{ mb: 3 }}

--- a/components/admin/MaterialTypeSelector.tsx
+++ b/components/admin/MaterialTypeSelector.tsx
@@ -91,7 +91,9 @@ export default function MaterialTypeSelector({
           }}
         >
           <CardActionArea
-            onClick={() => onSelect(mode)}
+            onClick={() => {
+              onSelect(mode);
+            }}
             aria-label={label}
             sx={{
               p: 3,


### PR DESCRIPTION
## Summary

Convert single-expression arrow functions to block body style in event handlers for consistency across material upload components.

**Files changed:**
- `app/admin/course-material/new/create-client.tsx` — 3 `onClick` handlers
- `components/admin/HTMLContentUploadForm.tsx` — `onChange` handler
- `components/admin/MaterialTypeSelector.tsx` — `onClick` handler

## Checklist

- [x] Quality Gates (lint, typecheck, tests) pass locally
  - Lint: Biome ✅
  - Typecheck: tsc --noEmit ✅
  - Tests: ✅ (276 passed, pre-existing coverage-gates failure unrelated)
- [ ] Live monitoring of Deploy workflow performed (pending)
- [ ] Branch hygiene executed or scheduled (pending post-merge)
- [x] Docs updated — not needed for style-only change

## Breaking Changes

- [x] Nein

## Risikobetrachtung / Rollback

Reine Style-Änderung (Arrow-Function-Body-Style). Kein funktionaler Unterschied. Rollback durch Revert des Commits.