### PR TITLE
fix: remaining lint fixes - floating promises, optional chaining, arrow body style

### DIFF
--- a/app/admin/course-material/new/create-client.tsx
+++ b/app/admin/course-material/new/create-client.tsx
@@ -216,7 +216,9 @@ export default function CreateCourseMaterialClient() {
           </Box>
           <SlideControlUploadForm
             onSubmit={handleSlideControlSubmit}
-            onCancel={() => router.push('/admin/course-material')}
+            onCancel={() => {
+              router.push('/admin/course-material');
+            }}
           />
         </Paper>
       )}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -106,7 +106,7 @@ export default function UsersPage() {
   }, [page, search, outperformerOnly, sortBy, sortOrder]);
 
   useEffect(() => {
-    fetchUsers();
+    void fetchUsers();
   }, [fetchUsers]);
 
   // Update URL when query params change

--- a/app/auth/custom-sign-in/page.tsx
+++ b/app/auth/custom-sign-in/page.tsx
@@ -9,7 +9,7 @@ export default async function CustomSignInRedirect({
   searchParams,
 }: PageProps) {
   const params = await searchParams;
-  const redirectUrl = params.redirect_url || params?.returnUrl || undefined;
+  const redirectUrl = params.redirect_url || params.returnUrl || undefined;
 
   const fallbackPath = '/sign-in';
   const rawBase = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL?.trim();

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -7,7 +7,7 @@ interface PageProps {
 
 export default async function SignInRedirectPage({ searchParams }: PageProps) {
   const params = await searchParams;
-  const redirectUrl = params.redirect_url || params?.returnUrl || undefined;
+  const redirectUrl = params.redirect_url || params.returnUrl || undefined;
 
   const fallbackPath = '/sign-in';
   const rawBase = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL?.trim();

--- a/app/my-courses/MyCoursesClient.tsx
+++ b/app/my-courses/MyCoursesClient.tsx
@@ -112,8 +112,8 @@ export const MyCoursesClient: React.FC<MyCoursesClientProps> = ({
               e.booking.id === bookingId
                 ? {
                     ...e,
-                    participation: result.data!.participation,
-                    hasSummaryAssets: result.data!.hasSummaryAssets,
+                    participation: result.data?.participation ?? null,
+                    hasSummaryAssets: result.data?.hasSummaryAssets ?? false,
                   }
                 : e
             )

--- a/app/my-courses/[bookingId]/TestimonialSectionMyCourses.tsx
+++ b/app/my-courses/[bookingId]/TestimonialSectionMyCourses.tsx
@@ -99,7 +99,7 @@ export default function TestimonialSectionMyCourses({
   }, [bookingId]);
 
   useEffect(() => {
-    fetchTestimonial();
+    void fetchTestimonial();
   }, [fetchTestimonial]);
 
   function handleSuccess() {
@@ -273,7 +273,9 @@ export default function TestimonialSectionMyCourses({
 
       <Button
         variant='contained'
-        onClick={() => setShowForm(true)}
+        onClick={() => {
+          setShowForm(true);
+        }}
         startIcon={<TestimonialIcon />}
       >
         Erfahrungsbericht schreiben

--- a/components/admin/CurriculumEditor.tsx
+++ b/components/admin/CurriculumEditor.tsx
@@ -310,9 +310,9 @@ export default function CurriculumEditor({
                 <IconButton
                   size='small'
                   color='error'
-                  onClick={e =>
-                    handleModuleDeleteClick(e, module.id, module.title)
-                  }
+                  onClick={e => {
+                    handleModuleDeleteClick(e, module.id, module.title);
+                  }}
                   disabled={disabled}
                   title='Tag löschen'
                 >

--- a/components/admin/PendingBookingsTable.tsx
+++ b/components/admin/PendingBookingsTable.tsx
@@ -134,7 +134,7 @@ export default function PendingBookingsTable({
   }, []);
 
   useEffect(() => {
-    fetchPendingBookings();
+    void fetchPendingBookings();
   }, [fetchPendingBookings]);
 
   const handleOpenReviewDialog = (

--- a/components/auth/UserProfileButton.tsx
+++ b/components/auth/UserProfileButton.tsx
@@ -286,7 +286,9 @@ export function UserProfileButton({
         {menuItems.map(item => (
           <MenuItem
             key={item.path}
-            onClick={() => handleNavigate(item.path)}
+            onClick={() => {
+              handleNavigate(item.path);
+            }}
             sx={{
               py: 1,
               '&:hover': {

--- a/components/participation/ResumeUploader.tsx
+++ b/components/participation/ResumeUploader.tsx
@@ -148,7 +148,7 @@ export const ResumeUploader: React.FC<ResumeUploaderProps> = ({
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
-      handleUpload(file);
+      void handleUpload(file);
     }
     // Reset input
     if (fileInputRef.current) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -31,7 +31,7 @@ function extractBearerToken(authorizationHeader: string | null): string | null {
     return null;
   }
 
-  const token = match[1]!.trim();
+  const token = match[1]?.trim();
   return token ? token : null;
 }
 


### PR DESCRIPTION
## Summary

Remaining lint fixes that were reverted or missed in previous PRs:
- Add `void` operator to floating promises in `useEffect` hooks
- Remove unnecessary optional chaining (`params.returnUrl`)
- Convert arrow functions to block body style in event handlers
- Replace non-null assertion (`!`) with optional chaining (`?.`) in `proxy.ts` and `MyCoursesClient.tsx`
- Fix type compatibility with `?? null` and `?? false` fallbacks

## Checklist

- [x] Quality Gates (lint, typecheck, tests) pass locally
  - Lint: Biome ✅
  - Typecheck: tsc --noEmit ✅
  - Tests: ✅ (276 passed, pre-existing coverage-gates failure unrelated)
- [ ] Live monitoring of Deploy workflow performed (pending)
- [ ] Branch hygiene executed or scheduled (pending post-merge)
- [x] Docs updated — not needed for lint-only changes

## Breaking Changes

- [x] Nein

## Risikobetrachtung / Rollback

Reine Lint-Fixes. Kein funktionaler Unterschied. Rollback durch Revert des Commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verbesserte Weiterleitungslogik beim Anmelden, damit Ziel-URLs zuverlässiger aus den verfügbaren Parametern übernommen werden.
  * Stabilere Anzeige beim Starten von Lernaktivitäten: Fehlende Daten werden jetzt defensiver behandelt.
  * Token-Erkennung im Hintergrund wurde robuster gemacht, was Anmelde- und API-Flows zuverlässiger unterstützt.

* **Refactor**
  * Mehrere Lade- und Klick-Handler wurden technisch bereinigt, ohne das sichtbare Verhalten zu ändern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->