### PR TITLE
chore: Rollbar keychain setup, Clerk MCP, caveman prompt

### DIFF
--- a/.github/prompts/caveman.prompt.md
+++ b/.github/prompts/caveman.prompt.md
@@ -1,0 +1,63 @@
+---
+name: caveman
+description: "Terse assistant mode. Cuts system + output tokens. Use /caveman to switch to compressed prose with exact code."
+argument-hint: "Optional: lite|full|ultra"
+agent: agent
+---
+
+The user input may be provided directly by chat or as an argument. Always use it.
+
+User input:
+
+$ARGUMENTS
+
+Caveman mode ON.
+
+Primary goal:
+- Minimum prose
+- Maximum signal
+- Keep code exact
+- Keep project conventions intact
+
+Response rules:
+- Drop articles, filler, pleasantries, hedging
+- Fragments OK. Short synonyms. Code/identifiers/paths/commands exact
+- Pattern: [thing] [action] [reason]. [next step].
+- No restate user request
+- If user asks simple question: answer short
+- If user asks for fix: focus root cause, not broad theory
+- If uncertain: say unknown briefly
+
+Code rules:
+- Code blocks stay normal, valid, complete
+- Do not compress code syntax
+- Keep identifiers, types, imports, commands exact
+- Preserve readability in patches, code samples, and shell commands
+- Use normal formatting for code, JSON, YAML, SQL, and tests
+- File paths, symbols, commands: keep precise
+
+Project rules:
+- Respect repository instructions and existing code style
+- Keep user-facing German text informal
+- Prefer concise technical German outside code
+- For reviews: findings first, ordered by severity
+- For debugging: hypothesis -> check -> result
+- For implementation: shortest correct explanation, then concrete action
+
+Clarity switch:
+- Normal style when: security warnings, irreversible ops, multi-step sequences where fragments risk misread, user asks to clarify
+
+Levels:
+- lite = tight pro
+- full (default) = classic caveman
+- ultra = max abbreviate
+- Switch: /caveman lite|full|ultra
+- Stop: "stop caveman" or "normal mode"
+
+Default output style:
+- Short
+- Direct
+- Technical
+- Useful
+
+If task needs detail, expand only where required.

--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,3 @@ public/_next-video
 
 # VSCode AI-generated Codacy instructions (do not commit)
 .github/instructions/codacy.instructions.md
-
-# Local agent prompt assets (tracked template ships as .example)
-.github/prompts/caveman-code.prompt.md
-!/.github/prompts/caveman-code.prompt.md.example

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -22,6 +22,10 @@
       "type": "stdio",
       "command": "npx",
       "args": ["@playwright/mcp@latest"]
+    },
+    "clerk": {
+      "type": "http",
+      "url": "https://mcp.clerk.com/mcp"
     }
   },
   "inputs": [

--- a/cspell.words.txt
+++ b/cspell.words.txt
@@ -694,3 +694,4 @@ ssrf
 trivy
 msgbox
 vascript
+Thalassa

--- a/docs/monitoring/rollbar-local-checklist.md
+++ b/docs/monitoring/rollbar-local-checklist.md
@@ -5,6 +5,12 @@ Hemera und Aither zusammen.
 
 Thalassa ist bewusst ausgenommen.
 
+> **Hinweis zu Pfaden:** Die `cd`-Befehle unten gehen von einem Workspace
+> Root aus, das die Repos `gaia/`, `hemera/` und `aither/` als parallele
+> Ordner enthält (z. B. `~/GitHub/`). Passe die Pfade an, falls deine
+> Layout abweicht. Alternativ kannst du das jeweilige Script direkt mit
+> dem absoluten Pfad aufrufen.
+
 ## Grundregeln
 
 - Verwende für serverseitige Ingestion immer einen echten
@@ -17,11 +23,12 @@ Thalassa ist bewusst ausgenommen.
 
 ## Gaia
 
+- Repo: `gaia/`
 - Datei: `gaia/.env.local`
 - Server-Token: `GAIA_ROLLBAR_ACCESS_TOKEN`
 - Optionale Diagnostik: `GAIA_ROLLBAR_DIAGNOSTICS=true`
 - Optionales Drain-Tuning: `GAIA_ROLLBAR_DELIVERY_WAIT_SECONDS=1`
-- Lokaler API-Check:
+- Lokaler API-Check (vom Workspace Root):
 
 ```bash
 cd gaia
@@ -33,15 +40,15 @@ curl -sS https://api.rollbar.com/api/1/item/ \
 
 - Erwartung: Rollbar antwortet mit `"err": 0`.
 
-- macOS Keychain-Setup mit Token-Test:
+- macOS Keychain-Setup mit Token-Test (vom Workspace Root):
 
 ```bash
-cd gaia
-bash scripts/rollbar-keychain-setup.sh
+bash gaia/scripts/rollbar-keychain-setup.sh
 ```
 
 ## Hemera
 
+- Repo: `hemera/`
 - Datei: `hemera/.env.local`
 - Server-Token: `ROLLBAR_HEMERA_SERVER_TOKEN`
 - Optionaler Browser-Token: `NEXT_PUBLIC_ROLLBAR_HEMERA_CLIENT_TOKEN`
@@ -50,7 +57,7 @@ bash scripts/rollbar-keychain-setup.sh
 - Wichtiger Hinweis: Zeitstempel-suffigierte Altvariablen in `.env.local`
   aktivieren Hemera nicht automatisch. Ihre Werte muessen in die kanonischen
   Namen kopiert werden.
-- Lokaler API-Check:
+- Lokaler API-Check (vom Workspace Root):
 
 ```bash
 cd hemera
@@ -62,15 +69,15 @@ curl -sS https://api.rollbar.com/api/1/item/ \
 
 - Erwartung: Rollbar antwortet mit `"err": 0`.
 
-- macOS Keychain-Setup mit Token-Test:
+- macOS Keychain-Setup mit Token-Test (vom Workspace Root):
 
 ```bash
-cd hemera
-bash scripts/rollbar-keychain-setup.sh
+bash hemera/scripts/rollbar-keychain-setup.sh
 ```
 
 ## Aither
 
+- Repo: `aither/`
 - Datei: `aither/.env.local`
 - Server-Token: `ROLLBAR_SERVER_TOKEN`
 - Optionaler Browser-Token: `NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN`
@@ -79,7 +86,7 @@ bash scripts/rollbar-keychain-setup.sh
 - Wichtiger Hinweis: In Aither ist der Serverpfad jetzt von der Browser-
   Aktivierung getrennt. `NEXT_PUBLIC_ROLLBAR_ENABLED=0` schaltet den
   Serverpfad nicht mehr ab.
-- Lokaler API-Check:
+- Lokaler API-Check (vom Workspace Root):
 
 ```bash
 cd aither
@@ -91,11 +98,10 @@ curl -sS https://api.rollbar.com/api/1/item/ \
 
 - Erwartung: Rollbar antwortet mit `"err": 0`.
 
-- macOS Keychain-Setup mit Token-Test:
+- macOS Keychain-Setup mit Token-Test (vom Workspace Root):
 
 ```bash
-cd aither
-bash scripts/rollbar-keychain-setup.sh
+bash aither/scripts/rollbar-keychain-setup.sh
 ```
 
 ## Abschlusscheck

--- a/docs/monitoring/rollbar-local-checklist.md
+++ b/docs/monitoring/rollbar-local-checklist.md
@@ -3,6 +3,8 @@
 Diese Checkliste fasst die verifizierten lokalen Rollbar-Setups für Gaia,
 Hemera und Aither zusammen.
 
+Thalassa ist bewusst ausgenommen.
+
 ## Grundregeln
 
 - Verwende für serverseitige Ingestion immer einen echten
@@ -31,6 +33,13 @@ curl -sS https://api.rollbar.com/api/1/item/ \
 
 - Erwartung: Rollbar antwortet mit `"err": 0`.
 
+- macOS Keychain-Setup mit Token-Test:
+
+```bash
+cd gaia
+bash scripts/rollbar-keychain-setup.sh
+```
+
 ## Hemera
 
 - Datei: `hemera/.env.local`
@@ -53,6 +62,13 @@ curl -sS https://api.rollbar.com/api/1/item/ \
 
 - Erwartung: Rollbar antwortet mit `"err": 0`.
 
+- macOS Keychain-Setup mit Token-Test:
+
+```bash
+cd hemera
+bash scripts/rollbar-keychain-setup.sh
+```
+
 ## Aither
 
 - Datei: `aither/.env.local`
@@ -74,6 +90,13 @@ curl -sS https://api.rollbar.com/api/1/item/ \
 ```
 
 - Erwartung: Rollbar antwortet mit `"err": 0`.
+
+- macOS Keychain-Setup mit Token-Test:
+
+```bash
+cd aither
+bash scripts/rollbar-keychain-setup.sh
+```
 
 ## Abschlusscheck
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:all": "npm run test:unit && npm run test:contracts && npm run test:e2e",
     "test:watch": "vitest",
     "test:prettier": "node tests/prettier-test-simple.js",
+    "rollbar:keychain": "bash scripts/rollbar-keychain-setup.sh",
     "set-admin-role": "npx tsx scripts/set-admin-role.ts",
     "format": "biome format --write .",
     "format:check": "biome check --formatter-enabled=true --linter-enabled=false .",

--- a/scripts/rollbar-keychain-setup.sh
+++ b/scripts/rollbar-keychain-setup.sh
@@ -7,11 +7,12 @@ FALLBACK_ENV_KEY="ROLLBAR_SERVER_TOKEN"
 PROJECT_NAME="hemera"
 KEYCHAIN_SERVICE="rollbar-hemera-post-server-item"
 DEFAULT_ENV_FILE=".env.local"
+CURRENT_USER="${USER:-$(id -un 2>/dev/null || echo "$UID")}"
 
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/rollbar-keychain-setup.sh [--token TOKEN] [--env-file PATH] [--keychain-service NAME]
+  scripts/rollbar-keychain-setup.sh [--token TOKEN] [--env-file PATH] [--keychain-service NAME] [--non-interactive]
 
 Description:
   1) Liest den Rollbar Server-Token (hemera) aus --token, Env oder Env-Datei.
@@ -20,16 +21,25 @@ Description:
 
 Token-Reihenfolge:
   --token > $ROLLBAR_HEMERA_SERVER_TOKEN > $ROLLBAR_SERVER_TOKEN > Env-Datei > interaktive Eingabe
+
+Optionen:
+  --non-interactive    Keine interaktive Eingabe; Fehler, wenn kein Token gefunden wird.
 EOF
 }
 
+# Strip surrounding quotes and whitespace from a token value.
 trim_token() {
   local value="$1"
-  value="${value#\"}"
-  value="${value%\"}"
-  value="${value#\'}"
-  value="${value%\'}"
-  printf '%s' "$(printf '%s' "$value" | tr -d '[:space:]')"
+  value="$(printf '%s' "$value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  if [[ "$value" == \"*\" ]]; then
+    value="${value#\"}"
+    value="${value%\"}"
+  fi
+  if [[ "$value" == \'*\' ]]; then
+    value="${value#\'}"
+    value="${value%\'}"
+  fi
+  printf '%s' "$value"
 }
 
 read_from_env_file() {
@@ -40,7 +50,7 @@ read_from_env_file() {
   fi
 
   local line
-  line=$(grep -E "^[[:space:]]*${key}=" "$env_file" | tail -n 1 || true)
+  line=$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "$env_file" | tail -n 1 || true)
   if [[ -z "$line" ]]; then
     return 1
   fi
@@ -63,8 +73,20 @@ assert_dependencies() {
   fi
 }
 
+# Escape a string for safe inclusion in a JSON string value.
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
 TOKEN=""
 ENV_FILE="$DEFAULT_ENV_FILE"
+NON_INTERACTIVE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -79,6 +101,10 @@ while [[ $# -gt 0 ]]; do
     --keychain-service)
       KEYCHAIN_SERVICE="${2:-}"
       shift 2
+      ;;
+    --non-interactive)
+      NON_INTERACTIVE="1"
+      shift
       ;;
     -h|--help)
       usage
@@ -111,6 +137,10 @@ if [[ -z "$TOKEN" ]]; then
 fi
 
 if [[ -z "$TOKEN" ]]; then
+  if [[ -n "$NON_INTERACTIVE" ]]; then
+    echo "Fehler: Kein Token gefunden und --non-interactive gesetzt." >&2
+    exit 1
+  fi
   read -r -s -p "Rollbar post_server_item Token fuer ${PROJECT_NAME} eingeben: " TOKEN
   echo ""
 fi
@@ -122,12 +152,18 @@ if [[ -z "$TOKEN" ]]; then
   exit 1
 fi
 
+escaped_token="$(json_escape "$TOKEN")"
+escaped_project="$(json_escape "$PROJECT_NAME")"
 payload=$(cat <<EOF
-{"access_token":"${TOKEN}","data":{"environment":"development","level":"info","body":{"message":{"body":"${PROJECT_NAME} keychain setup probe"}}}}
+{"access_token":"${escaped_token}","data":{"environment":"development","level":"info","body":{"message":{"body":"${escaped_project} keychain setup probe"}}}}
 EOF
 )
 
-response=$(curl -sS "$ROLLBAR_API_URL" -H "Content-Type: application/json" -d "$payload" || true)
+# Send payload via stdin to avoid exposing the token in process argument lists.
+response=$(curl -sS "$ROLLBAR_API_URL" -H "Content-Type: application/json" --data-binary @- <<EOF || true
+$payload
+EOF
+)
 
 if ! printf '%s' "$response" | tr -d '[:space:]' | grep -q '"err":0'; then
   echo "Fehler: Token-Test fehlgeschlagen." >&2
@@ -135,8 +171,8 @@ if ! printf '%s' "$response" | tr -d '[:space:]' | grep -q '"err":0'; then
   exit 1
 fi
 
-security add-generic-password -a "$USER" -s "$KEYCHAIN_SERVICE" -w "$TOKEN" -U >/dev/null
-stored_token=$(security find-generic-password -a "$USER" -s "$KEYCHAIN_SERVICE" -w)
+security add-generic-password -a "$CURRENT_USER" -s "$KEYCHAIN_SERVICE" -w "$TOKEN" -U >/dev/null
+stored_token=$(security find-generic-password -a "$CURRENT_USER" -s "$KEYCHAIN_SERVICE" -w)
 
 if [[ "$stored_token" != "$TOKEN" ]]; then
   echo "Fehler: Token konnte nicht korrekt aus der Keychain gelesen werden." >&2
@@ -148,4 +184,4 @@ echo "Token wurde in der Keychain gespeichert."
 echo "Service: $KEYCHAIN_SERVICE"
 echo ""
 echo "Optional fuer die aktuelle Shell:"
-echo "export ROLLBAR_HEMERA_SERVER_TOKEN=\"\$(security find-generic-password -a \"$USER\" -s \"$KEYCHAIN_SERVICE\" -w)\""
+echo "export ROLLBAR_HEMERA_SERVER_TOKEN=\"\$(security find-generic-password -a \"$CURRENT_USER\" -s \"$KEYCHAIN_SERVICE\" -w)\""

--- a/scripts/rollbar-keychain-setup.sh
+++ b/scripts/rollbar-keychain-setup.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROLLBAR_API_URL="https://api.rollbar.com/api/1/item/"
+PRIMARY_ENV_KEY="ROLLBAR_HEMERA_SERVER_TOKEN"
+FALLBACK_ENV_KEY="ROLLBAR_SERVER_TOKEN"
+PROJECT_NAME="hemera"
+KEYCHAIN_SERVICE="rollbar-hemera-post-server-item"
+DEFAULT_ENV_FILE=".env.local"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/rollbar-keychain-setup.sh [--token TOKEN] [--env-file PATH] [--keychain-service NAME]
+
+Description:
+  1) Liest den Rollbar Server-Token (hemera) aus --token, Env oder Env-Datei.
+  2) Testet den Token gegen die Rollbar Ingest API.
+  3) Speichert den Token bei Erfolg in der macOS Keychain.
+
+Token-Reihenfolge:
+  --token > $ROLLBAR_HEMERA_SERVER_TOKEN > $ROLLBAR_SERVER_TOKEN > Env-Datei > interaktive Eingabe
+EOF
+}
+
+trim_token() {
+  local value="$1"
+  value="${value#\"}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value%\'}"
+  printf '%s' "$(printf '%s' "$value" | tr -d '[:space:]')"
+}
+
+read_from_env_file() {
+  local env_file="$1"
+  local key="$2"
+  if [[ ! -f "$env_file" ]]; then
+    return 1
+  fi
+
+  local line
+  line=$(grep -E "^[[:space:]]*${key}=" "$env_file" | tail -n 1 || true)
+  if [[ -z "$line" ]]; then
+    return 1
+  fi
+
+  local raw
+  raw="${line#*=}"
+  raw="${raw%%#*}"
+  trim_token "$raw"
+}
+
+assert_dependencies() {
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "Fehler: curl ist nicht installiert." >&2
+    exit 1
+  fi
+
+  if ! command -v security >/dev/null 2>&1; then
+    echo "Fehler: macOS security CLI wurde nicht gefunden." >&2
+    exit 1
+  fi
+}
+
+TOKEN=""
+ENV_FILE="$DEFAULT_ENV_FILE"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --token)
+      TOKEN="${2:-}"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="${2:-}"
+      shift 2
+      ;;
+    --keychain-service)
+      KEYCHAIN_SERVICE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unbekanntes Argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+assert_dependencies
+
+if [[ -z "$TOKEN" && -n "${ROLLBAR_HEMERA_SERVER_TOKEN:-}" ]]; then
+  TOKEN="${ROLLBAR_HEMERA_SERVER_TOKEN}"
+fi
+
+if [[ -z "$TOKEN" && -n "${ROLLBAR_SERVER_TOKEN:-}" ]]; then
+  TOKEN="${ROLLBAR_SERVER_TOKEN}"
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  TOKEN="$(read_from_env_file "$ENV_FILE" "$PRIMARY_ENV_KEY" || true)"
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  TOKEN="$(read_from_env_file "$ENV_FILE" "$FALLBACK_ENV_KEY" || true)"
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  read -r -s -p "Rollbar post_server_item Token fuer ${PROJECT_NAME} eingeben: " TOKEN
+  echo ""
+fi
+
+TOKEN="$(trim_token "$TOKEN")"
+
+if [[ -z "$TOKEN" ]]; then
+  echo "Fehler: Kein Token gefunden." >&2
+  exit 1
+fi
+
+payload=$(cat <<EOF
+{"access_token":"${TOKEN}","data":{"environment":"development","level":"info","body":{"message":{"body":"${PROJECT_NAME} keychain setup probe"}}}}
+EOF
+)
+
+response=$(curl -sS "$ROLLBAR_API_URL" -H "Content-Type: application/json" -d "$payload" || true)
+
+if ! printf '%s' "$response" | tr -d '[:space:]' | grep -q '"err":0'; then
+  echo "Fehler: Token-Test fehlgeschlagen." >&2
+  echo "Rollbar Antwort: $response" >&2
+  exit 1
+fi
+
+security add-generic-password -a "$USER" -s "$KEYCHAIN_SERVICE" -w "$TOKEN" -U >/dev/null
+stored_token=$(security find-generic-password -a "$USER" -s "$KEYCHAIN_SERVICE" -w)
+
+if [[ "$stored_token" != "$TOKEN" ]]; then
+  echo "Fehler: Token konnte nicht korrekt aus der Keychain gelesen werden." >&2
+  exit 1
+fi
+
+echo "Token-Test erfolgreich (err=0)."
+echo "Token wurde in der Keychain gespeichert."
+echo "Service: $KEYCHAIN_SERVICE"
+echo ""
+echo "Optional fuer die aktuelle Shell:"
+echo "export ROLLBAR_HEMERA_SERVER_TOKEN=\"\$(security find-generic-password -a \"$USER\" -s \"$KEYCHAIN_SERVICE\" -w)\""


### PR DESCRIPTION
## Summary

- `scripts/rollbar-keychain-setup.sh`: macOS Keychain token storage + Rollbar API test
- `package.json`: add `rollbar:keychain` script
- `mcp.json`: add Clerk HTTP MCP server
- `docs/monitoring/rollbar-local-checklist.md`: add keychain setup sections for Gaia/Hemera/Aither
- `.gitignore`: remove obsolete `caveman-code.prompt.md` ignore (template now tracked)
- `cspell.words.txt`: add "Thalassa"
- `caveman.prompt.md`: compressed assistant mode