### PR TITLE
fix(biome): migrate config to 2.5.3 schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -35,7 +35,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": {
         "noNonNullAssertion": "off",
         "useConst": "warn",


### PR DESCRIPTION
## Summary

- Biome config schema was outdated (2.4.12 vs CLI 2.5.3) → parsing errors
- `recommended` field deprecated → replaced with `preset: "recommended"`
- Auto-migrated via `biome migrate --write`

## Verification

`npx biome check` → ✅ 433 files, no errors