### PR TITLE
refactor(api): deduplicate participation routes and admin CORS boilerplate

### DIFF
--- a/.github/prompts/push.prompt.md
+++ b/.github/prompts/push.prompt.md
@@ -1,7 +1,6 @@
 ---
 name: push
 description: Lint, test, commit, push, open PR, resolve reviews, merge to main
-model: Claude Haiku
 ---
 ## Pre-flight
 - Run lint, format check, typecheck, spellcheck, build, and tests; stop on failure.

--- a/app/api/admin/bookings/[id]/review/route.ts
+++ b/app/api/admin/bookings/[id]/review/route.ts
@@ -1,6 +1,5 @@
-import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
-import { checkUserAdminStatus } from '../../../../../../lib/auth/helpers';
+import { requireAdminUser } from '../../../../../../lib/auth/helpers';
 import { prisma } from '../../../../../../lib/db/prisma';
 import { serverInstance } from '../../../../../../lib/monitoring/rollbar-official';
 import { bookingReviewSchema } from '../../../../../../lib/schemas/admin/booking';
@@ -10,14 +9,14 @@ import {
   createSuccessResponse,
   ErrorCodes,
 } from '../../../../../../lib/utils/api-response';
+import {
+  applyCorsHeaders,
+  getCorsHeaders,
+} from '../../../../../../lib/utils/cors';
 import { getOrCreateRequestId } from '../../../../../../lib/utils/request-id';
 
 // CORS headers for external app access
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'PATCH, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-};
+const corsHeaders = getCorsHeaders();
 
 export async function OPTIONS() {
   return NextResponse.json({}, { headers: corsHeaders });
@@ -55,93 +54,54 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
     // Validate booking ID
     if (!bookingId || bookingId.trim() === '') {
-      const errorResponse = createErrorResponse(
-        'Invalid booking ID',
-        ErrorCodes.VALIDATION_ERROR,
-        requestId,
-        400
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Invalid booking ID',
+          ErrorCodes.VALIDATION_ERROR,
+          requestId,
+          400
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
-    // Authentication check
-    let userId: string | null = null;
-    try {
-      const authResult = await auth();
-      userId = authResult.userId;
-    } catch (_authError) {
-      const errorResponse = createErrorResponse(
-        'Unauthorized access',
-        ErrorCodes.UNAUTHORIZED,
-        requestId,
-        401
-      );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
+    // Admin authentication + authorization
+    const adminAuth = await requireAdminUser(requestId);
+    if (!adminAuth.authorized) {
+      return applyCorsHeaders(adminAuth.response, corsHeaders);
     }
-
-    if (!userId) {
-      const errorResponse = createErrorResponse(
-        'Unauthorized access',
-        ErrorCodes.UNAUTHORIZED,
-        requestId,
-        401
-      );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
-    }
-
-    // Admin authorization check
-    const isAdmin = await checkUserAdminStatus();
-    if (!isAdmin) {
-      const errorResponse = createErrorResponse(
-        'Admin privileges required',
-        ErrorCodes.FORBIDDEN,
-        requestId,
-        403
-      );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
-    }
+    const userId = adminAuth.userId;
 
     // Parse and validate request body
     let body: unknown;
     try {
       body = await request.json();
     } catch (_parseError) {
-      const errorResponse = createErrorResponse(
-        'Invalid JSON body',
-        ErrorCodes.VALIDATION_ERROR,
-        requestId,
-        400
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Invalid JSON body',
+          ErrorCodes.VALIDATION_ERROR,
+          requestId,
+          400
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     const parseResult = bookingReviewSchema.safeParse(body);
     if (!parseResult.success) {
-      const errorResponse = createErrorResponse(
-        `Validation error: ${parseResult.error.issues.map(e => e.message).join(', ')}`,
-        ErrorCodes.VALIDATION_ERROR,
-        requestId,
-        400
+      const validationMessages = parseResult.error.issues
+        .map(e => e.message)
+        .join(', ');
+      return applyCorsHeaders(
+        createErrorResponse(
+          `Validation error: ${validationMessages}`,
+          ErrorCodes.VALIDATION_ERROR,
+          requestId,
+          400
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     const { action } = parseResult.data;
@@ -165,30 +125,28 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     });
 
     if (!booking) {
-      const errorResponse = createErrorResponse(
-        'Booking not found',
-        ErrorCodes.NOT_FOUND,
-        requestId,
-        404
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Booking not found',
+          ErrorCodes.NOT_FOUND,
+          requestId,
+          404
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     // Ensure booking is in PRE_BOOKED status
     if (booking.paymentStatus !== 'PRE_BOOKED') {
-      const errorResponse = createErrorResponse(
-        'Booking is not in pending review status',
-        ErrorCodes.CONFLICT,
-        requestId,
-        409
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Booking is not in pending review status',
+          ErrorCodes.CONFLICT,
+          requestId,
+          409
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     if (action === 'approve') {
@@ -208,37 +166,35 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
       // Check if the update succeeded (count > 0)
       if (updatedBooking.count === 0) {
-        const errorResponse = createErrorResponse(
-          'Booking status changed during review (possible race condition)',
-          ErrorCodes.CONFLICT,
-          requestId,
-          409
+        return applyCorsHeaders(
+          createErrorResponse(
+            'Booking status changed during review (possible race condition)',
+            ErrorCodes.CONFLICT,
+            requestId,
+            409
+          ),
+          corsHeaders
         );
-        Object.entries(corsHeaders).forEach(([key, value]) => {
-          errorResponse.headers.set(key, value);
-        });
-        return errorResponse;
       }
 
       // Fetch updated booking for response
-      const booking = await prisma.booking.findUnique({
+      const updatedBookingData = await prisma.booking.findUnique({
         where: { id: bookingId },
       });
 
-      const successResponse = createSuccessResponse(
-        {
-          id: booking?.id,
-          paymentStatus: booking?.paymentStatus,
-          reviewedAt: booking?.reviewedAt?.toISOString(),
-          reviewedBy: booking?.reviewedBy,
-          message: 'Booking approved successfully',
-        },
-        requestId
+      return applyCorsHeaders(
+        createSuccessResponse(
+          {
+            id: updatedBookingData?.id,
+            paymentStatus: updatedBookingData?.paymentStatus,
+            reviewedAt: updatedBookingData?.reviewedAt?.toISOString(),
+            reviewedBy: updatedBookingData?.reviewedBy,
+            message: 'Booking approved successfully',
+          },
+          requestId
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        successResponse.headers.set(key, value);
-      });
-      return successResponse;
     } else {
       // Reject: Send rejection email and delete booking
       // Use atomic delete with status precondition to prevent race conditions
@@ -276,29 +232,27 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
       // Check if deletion succeeded
       if (deleteResult.count === 0) {
-        const errorResponse = createErrorResponse(
-          'Booking status changed during review (possible race condition)',
-          ErrorCodes.CONFLICT,
-          requestId,
-          409
+        return applyCorsHeaders(
+          createErrorResponse(
+            'Booking status changed during review (possible race condition)',
+            ErrorCodes.CONFLICT,
+            requestId,
+            409
+          ),
+          corsHeaders
         );
-        Object.entries(corsHeaders).forEach(([key, value]) => {
-          errorResponse.headers.set(key, value);
-        });
-        return errorResponse;
       }
 
-      const successResponse = createSuccessResponse(
-        {
-          id: bookingId,
-          message: 'Booking rejected and removed',
-        },
-        requestId
+      return applyCorsHeaders(
+        createSuccessResponse(
+          {
+            id: bookingId,
+            message: 'Booking rejected and removed',
+          },
+          requestId
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        successResponse.headers.set(key, value);
-      });
-      return successResponse;
     }
   } catch (error) {
     // Log minimal context without full error object
@@ -308,15 +262,14 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       requestId,
       error: error instanceof Error ? error.message : 'Unknown error',
     });
-    const errorResponse = createErrorResponse(
-      'Failed to process booking review',
-      ErrorCodes.INTERNAL_ERROR,
-      requestId,
-      500
+    return applyCorsHeaders(
+      createErrorResponse(
+        'Failed to process booking review',
+        ErrorCodes.INTERNAL_ERROR,
+        requestId,
+        500
+      ),
+      corsHeaders
     );
-    Object.entries(corsHeaders).forEach(([key, value]) => {
-      errorResponse.headers.set(key, value);
-    });
-    return errorResponse;
   }
 }

--- a/app/api/admin/bookings/pending/route.ts
+++ b/app/api/admin/bookings/pending/route.ts
@@ -1,6 +1,5 @@
-import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
-import { checkUserAdminStatus } from '../../../../../lib/auth/helpers';
+import { requireAdminUser } from '../../../../../lib/auth/helpers';
 import { prisma } from '../../../../../lib/db/prisma';
 import { serverInstance } from '../../../../../lib/monitoring/rollbar-official';
 import {
@@ -8,14 +7,14 @@ import {
   createSuccessResponse,
   ErrorCodes,
 } from '../../../../../lib/utils/api-response';
+import {
+  applyCorsHeaders,
+  getCorsHeaders,
+} from '../../../../../lib/utils/cors';
 import { getOrCreateRequestId } from '../../../../../lib/utils/request-id';
 
 // CORS headers for external app access
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-};
+const corsHeaders = getCorsHeaders();
 
 export async function OPTIONS() {
   return NextResponse.json({}, { headers: corsHeaders });
@@ -30,50 +29,10 @@ export async function GET(request: NextRequest) {
   const requestId = getOrCreateRequestId(request);
 
   try {
-    // Authentication check
-    let userId: string | null = null;
-    try {
-      const authResult = await auth();
-      userId = authResult.userId;
-    } catch (_authError) {
-      const errorResponse = createErrorResponse(
-        'Unauthorized access',
-        ErrorCodes.UNAUTHORIZED,
-        requestId,
-        401
-      );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
-    }
-
-    if (!userId) {
-      const errorResponse = createErrorResponse(
-        'Unauthorized access',
-        ErrorCodes.UNAUTHORIZED,
-        requestId,
-        401
-      );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
-    }
-
-    // Admin authorization check
-    const isAdmin = await checkUserAdminStatus();
-    if (!isAdmin) {
-      const errorResponse = createErrorResponse(
-        'Admin privileges required',
-        ErrorCodes.FORBIDDEN,
-        requestId,
-        403
-      );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
+    // Admin authentication + authorization
+    const adminAuth = await requireAdminUser(requestId);
+    if (!adminAuth.authorized) {
+      return applyCorsHeaders(adminAuth.response, corsHeaders);
     }
 
     // Fetch pending bookings with PRE_BOOKED status
@@ -124,11 +83,10 @@ export async function GET(request: NextRequest) {
       },
     }));
 
-    const successResponse = createSuccessResponse(response, requestId);
-    Object.entries(corsHeaders).forEach(([key, value]) => {
-      successResponse.headers.set(key, value);
-    });
-    return successResponse;
+    return applyCorsHeaders(
+      createSuccessResponse(response, requestId),
+      corsHeaders
+    );
   } catch (error) {
     // Log minimal context without full error object
     serverInstance.error('Failed to fetch pending bookings', {
@@ -136,15 +94,14 @@ export async function GET(request: NextRequest) {
       requestId,
       error: error instanceof Error ? error.message : 'Unknown error',
     });
-    const errorResponse = createErrorResponse(
-      'Failed to fetch pending bookings',
-      ErrorCodes.INTERNAL_ERROR,
-      requestId,
-      500
+    return applyCorsHeaders(
+      createErrorResponse(
+        'Failed to fetch pending bookings',
+        ErrorCodes.INTERNAL_ERROR,
+        requestId,
+        500
+      ),
+      corsHeaders
     );
-    Object.entries(corsHeaders).forEach(([key, value]) => {
-      errorResponse.headers.set(key, value);
-    });
-    return errorResponse;
   }
 }

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -40,16 +40,15 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     // Validate user ID
     if (!targetUserId || targetUserId.trim() === '') {
-      const errorResponse = createErrorResponse(
-        'Ungültige Benutzer-ID',
-        ErrorCodes.VALIDATION_ERROR,
-        requestId,
-        400
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Ungültige Benutzer-ID',
+          ErrorCodes.VALIDATION_ERROR,
+          requestId,
+          400
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     const adminAuth = await requireAdminUser(requestId);
@@ -71,23 +70,21 @@ export async function GET(request: NextRequest, context: RouteContext) {
     });
 
     if (!user) {
-      const errorResponse = createErrorResponse(
-        'Benutzer nicht gefunden',
-        ErrorCodes.NOT_FOUND,
-        requestId,
-        404
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Benutzer nicht gefunden',
+          ErrorCodes.NOT_FOUND,
+          requestId,
+          404
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
-    const successResponse = createSuccessResponse(user, requestId);
-    Object.entries(corsHeaders).forEach(([key, value]) => {
-      successResponse.headers.set(key, value);
-    });
-    return successResponse;
+    return applyCorsHeaders(
+      createSuccessResponse(user, requestId),
+      corsHeaders
+    );
   } catch (error) {
     // Log minimal context without full error object
     serverInstance.error('Fehler beim Laden der Benutzerdetails', {
@@ -96,16 +93,15 @@ export async function GET(request: NextRequest, context: RouteContext) {
       requestId,
       error: error instanceof Error ? error.message : 'Unknown error',
     });
-    const errorResponse = createErrorResponse(
-      'Benutzerdetails konnten nicht geladen werden',
-      ErrorCodes.INTERNAL_ERROR,
-      requestId,
-      500
+    return applyCorsHeaders(
+      createErrorResponse(
+        'Benutzerdetails konnten nicht geladen werden',
+        ErrorCodes.INTERNAL_ERROR,
+        requestId,
+        500
+      ),
+      corsHeaders
     );
-    Object.entries(corsHeaders).forEach(([key, value]) => {
-      errorResponse.headers.set(key, value);
-    });
-    return errorResponse;
   }
 }
 
@@ -124,16 +120,15 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
     // Validate user ID
     if (!targetUserId || targetUserId.trim() === '') {
-      const errorResponse = createErrorResponse(
-        'Ungültige Benutzer-ID',
-        ErrorCodes.VALIDATION_ERROR,
-        requestId,
-        400
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Ungültige Benutzer-ID',
+          ErrorCodes.VALIDATION_ERROR,
+          requestId,
+          400
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     const adminAuth = await requireAdminUser(requestId);
@@ -148,46 +143,46 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     try {
       body = await request.json();
     } catch (_parseError) {
-      const errorResponse = createErrorResponse(
-        'Ungültiger JSON-Body',
-        ErrorCodes.VALIDATION_ERROR,
-        requestId,
-        400
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Ungültiger JSON-Body',
+          ErrorCodes.VALIDATION_ERROR,
+          requestId,
+          400
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     const parseResult = userPatchSchema.safeParse(body);
     if (!parseResult.success) {
-      const errorResponse = createErrorResponse(
-        `Validierungsfehler: ${parseResult.error.issues.map(e => e.message).join(', ')}`,
-        ErrorCodes.VALIDATION_ERROR,
-        requestId,
-        400
+      const validationMessages = parseResult.error.issues
+        .map(e => e.message)
+        .join(', ');
+      return applyCorsHeaders(
+        createErrorResponse(
+          `Validierungsfehler: ${validationMessages}`,
+          ErrorCodes.VALIDATION_ERROR,
+          requestId,
+          400
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     const { role, isOutperformer } = parseResult.data;
 
     // Prevent self-demotion: admin cannot remove their own admin role
     if (role !== undefined && userId === targetUserId && role !== 'admin') {
-      const errorResponse = createErrorResponse(
-        'Du kannst deine eigene Admin-Rolle nicht entfernen',
-        ErrorCodes.FORBIDDEN,
-        requestId,
-        403
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Du kannst deine eigene Admin-Rolle nicht entfernen',
+          ErrorCodes.FORBIDDEN,
+          requestId,
+          403
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     let updatedUser: unknown = null;
@@ -214,16 +209,15 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       });
 
       if (!existingUser) {
-        const errorResponse = createErrorResponse(
-          'Benutzer nicht gefunden',
-          ErrorCodes.NOT_FOUND,
-          requestId,
-          404
+        return applyCorsHeaders(
+          createErrorResponse(
+            'Benutzer nicht gefunden',
+            ErrorCodes.NOT_FOUND,
+            requestId,
+            404
+          ),
+          corsHeaders
         );
-        Object.entries(corsHeaders).forEach(([key, value]) => {
-          errorResponse.headers.set(key, value);
-        });
-        return errorResponse;
       }
 
       updatedUser = await prisma.user.update({
@@ -249,24 +243,22 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     }
 
     if (updatedUser) {
-      const successResponse = createSuccessResponse(updatedUser, requestId);
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        successResponse.headers.set(key, value);
-      });
-      return successResponse;
+      return applyCorsHeaders(
+        createSuccessResponse(updatedUser, requestId),
+        corsHeaders
+      );
     }
 
     // Should not reach here due to schema validation
-    const errorResponse = createErrorResponse(
-      'Keine gültige Aktion angegeben',
-      ErrorCodes.VALIDATION_ERROR,
-      requestId,
-      400
+    return applyCorsHeaders(
+      createErrorResponse(
+        'Keine gültige Aktion angegeben',
+        ErrorCodes.VALIDATION_ERROR,
+        requestId,
+        400
+      ),
+      corsHeaders
     );
-    Object.entries(corsHeaders).forEach(([key, value]) => {
-      errorResponse.headers.set(key, value);
-    });
-    return errorResponse;
   } catch (error) {
     serverInstance.error('Fehler beim Aktualisieren des Benutzers', {
       context: 'AdminUsers.PATCH',
@@ -274,16 +266,15 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       requestId,
       error: error instanceof Error ? error.message : 'Unknown error',
     });
-    const errorResponse = createErrorResponse(
-      'Benutzer konnte nicht aktualisiert werden',
-      ErrorCodes.INTERNAL_ERROR,
-      requestId,
-      500
+    return applyCorsHeaders(
+      createErrorResponse(
+        'Benutzer konnte nicht aktualisiert werden',
+        ErrorCodes.INTERNAL_ERROR,
+        requestId,
+        500
+      ),
+      corsHeaders
     );
-    Object.entries(corsHeaders).forEach(([key, value]) => {
-      errorResponse.headers.set(key, value);
-    });
-    return errorResponse;
   }
 }
 
@@ -301,16 +292,15 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
 
     // Validate user ID
     if (!targetUserId || targetUserId.trim() === '') {
-      const errorResponse = createErrorResponse(
-        'Ungültige Benutzer-ID',
-        ErrorCodes.VALIDATION_ERROR,
-        requestId,
-        400
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Ungültige Benutzer-ID',
+          ErrorCodes.VALIDATION_ERROR,
+          requestId,
+          400
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     const adminAuth = await requireAdminUser(requestId);
@@ -322,16 +312,15 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
 
     // Prevent self-deletion
     if (userId === targetUserId) {
-      const errorResponse = createErrorResponse(
-        'Du kannst dein eigenes Konto nicht löschen',
-        ErrorCodes.FORBIDDEN,
-        requestId,
-        403
+      return applyCorsHeaders(
+        createErrorResponse(
+          'Du kannst dein eigenes Konto nicht löschen',
+          ErrorCodes.FORBIDDEN,
+          requestId,
+          403
+        ),
+        corsHeaders
       );
-      Object.entries(corsHeaders).forEach(([key, value]) => {
-        errorResponse.headers.set(key, value);
-      });
-      return errorResponse;
     }
 
     // Delete user via Clerk
@@ -357,15 +346,14 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
       requestId,
       error: error instanceof Error ? error.message : 'Unknown error',
     });
-    const errorResponse = createErrorResponse(
-      'Benutzer konnte nicht gelöscht werden',
-      ErrorCodes.INTERNAL_ERROR,
-      requestId,
-      500
+    return applyCorsHeaders(
+      createErrorResponse(
+        'Benutzer konnte nicht gelöscht werden',
+        ErrorCodes.INTERNAL_ERROR,
+        requestId,
+        500
+      ),
+      corsHeaders
     );
-    Object.entries(corsHeaders).forEach(([key, value]) => {
-      errorResponse.headers.set(key, value);
-    });
-    return errorResponse;
   }
 }

--- a/app/api/my-courses/[bookingId]/debriefing/route.ts
+++ b/app/api/my-courses/[bookingId]/debriefing/route.ts
@@ -5,17 +5,18 @@
  * PUT - Update debriefing data (save/complete)
  */
 
-import { auth } from '@clerk/nextjs/server';
-import { type NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
+  withParticipationGetHandler,
+  withParticipationMutationHandler,
+} from '@/lib/api/participation-route-handler';
+import {
   completeDebriefingStep,
-  getParticipationByBookingId,
   updateDebriefing,
 } from '@/lib/db/courseParticipation';
 import { serverInstance } from '@/lib/monitoring/rollbar-official';
 
-// Zod schema for debriefing input
 const debriefingSchema = z.object({
   debriefingPlan: z.string().max(2000).optional(),
   salaryDiscussionMonth: z
@@ -25,119 +26,27 @@ const debriefingSchema = z.object({
   complete: z.boolean().optional(),
 });
 
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
-
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized debriefing access', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
-    return NextResponse.json({
+export const GET = withParticipationGetHandler(
+  '/api/my-courses/[bookingId]/debriefing',
+  ({ participation }) =>
+    NextResponse.json({
       success: true,
       data: {
         debriefingPlan: participation.debriefingPlan,
         salaryDiscussionMonth: participation.salaryDiscussionMonth,
         status: participation.status,
       },
-    });
-  } catch (error) {
-    serverInstance.error(
-      'Error in GET /api/my-courses/[bookingId]/debriefing',
-      {
-        error: error instanceof Error ? error.message : String(error),
-      }
-    );
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
-  }
-}
+    })
+);
 
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
+export const PUT = withParticipationMutationHandler(
+  '/api/my-courses/[bookingId]/debriefing',
+  debriefingSchema,
+  async ({ participation, body, userId, bookingId }) => {
+    const { complete, ...debriefingData } = body;
 
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    // Parse and validate body
-    const body = await request.json();
-    const parseResult = debriefingSchema.safeParse(body);
-
-    if (!parseResult.success) {
-      return NextResponse.json(
-        { error: 'Invalid data', details: parseResult.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { complete, ...debriefingData } = parseResult.data;
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized debriefing update', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
-    // Update debriefing data
     await updateDebriefing(participation.id, debriefingData);
 
-    // If completing, advance to next step
     if (complete) {
       await completeDebriefingStep(participation.id);
       serverInstance.info('Debriefing step completed', {
@@ -151,16 +60,5 @@ export async function PUT(
       success: true,
       message: complete ? 'Debriefing completed' : 'Data saved',
     });
-  } catch (error) {
-    serverInstance.error(
-      'Error in PUT /api/my-courses/[bookingId]/debriefing',
-      {
-        error: error instanceof Error ? error.message : String(error),
-      }
-    );
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);

--- a/app/api/my-courses/[bookingId]/preparation/route.ts
+++ b/app/api/my-courses/[bookingId]/preparation/route.ts
@@ -5,17 +5,18 @@
  * PUT - Update preparation data (save/complete)
  */
 
-import { auth } from '@clerk/nextjs/server';
-import { type NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
+  withParticipationGetHandler,
+  withParticipationMutationHandler,
+} from '@/lib/api/participation-route-handler';
+import {
   completePreparationStep,
-  getParticipationByBookingId,
   updatePreparation,
-} from '../../../../../lib/db/courseParticipation';
-import { serverInstance } from '../../../../../lib/monitoring/rollbar-official';
+} from '@/lib/db/courseParticipation';
+import { serverInstance } from '@/lib/monitoring/rollbar-official';
 
-// Zod schema for preparation input
 const preparationSchema = z.object({
   preparationIntent: z.string().max(2000).optional(),
   desiredResults: z.string().max(2000).optional(),
@@ -23,44 +24,10 @@ const preparationSchema = z.object({
   complete: z.boolean().optional(),
 });
 
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
-
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized preparation access', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
-    return NextResponse.json({
+export const GET = withParticipationGetHandler(
+  '/api/my-courses/[bookingId]/preparation',
+  ({ participation }) =>
+    NextResponse.json({
       success: true,
       data: {
         preparationIntent: participation.preparationIntent,
@@ -69,75 +36,17 @@ export async function GET(
         preparationCompletedAt: participation.preparationCompletedAt,
         status: participation.status,
       },
-    });
-  } catch (error) {
-    serverInstance.error(
-      'Error in GET /api/my-courses/[bookingId]/preparation',
-      {
-        error: error instanceof Error ? error.message : String(error),
-      }
-    );
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
-  }
-}
+    })
+);
 
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
+export const PUT = withParticipationMutationHandler(
+  '/api/my-courses/[bookingId]/preparation',
+  preparationSchema,
+  async ({ participation, body, userId, bookingId }) => {
+    const { complete, ...preparationData } = body;
 
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    // Parse and validate body
-    const body = await request.json();
-    const parseResult = preparationSchema.safeParse(body);
-
-    if (!parseResult.success) {
-      return NextResponse.json(
-        { error: 'Invalid data', details: parseResult.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { complete, ...preparationData } = parseResult.data;
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized preparation update', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
-    // Update preparation data
     await updatePreparation(participation.id, preparationData, complete);
 
-    // If completing, advance to next step
     if (complete) {
       await completePreparationStep(participation.id);
       serverInstance.info('Preparation step completed', {
@@ -151,16 +60,5 @@ export async function PUT(
       success: true,
       message: complete ? 'Preparation completed' : 'Data saved',
     });
-  } catch (error) {
-    serverInstance.error(
-      'Error in PUT /api/my-courses/[bookingId]/preparation',
-      {
-        error: error instanceof Error ? error.message : String(error),
-      }
-    );
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);

--- a/app/api/my-courses/[bookingId]/result/result-handlers.ts
+++ b/app/api/my-courses/[bookingId]/result/result-handlers.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared result step handlers for result and results routes.
+ *
+ * Both `/result` and `/results` routes share the same schema and logic.
+ * The only difference is the user-facing language: `result` uses English,
+ * `results` uses German (informal "Du").
+ */
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  type ParticipationRouteContext,
+  withParticipationGetHandler,
+  withParticipationMutationHandler,
+} from '@/lib/api/participation-route-handler';
+import { completeResultStep, updateResult } from '@/lib/db/courseParticipation';
+import { serverInstance } from '@/lib/monitoring/rollbar-official';
+
+/** Shared Zod schema for both result and results routes. */
+export const resultStepSchema = z.object({
+  resultOutcome: z.string().max(2000).optional(),
+  resultNotes: z.string().max(2000).optional(),
+  complete: z.boolean().optional(),
+});
+
+/** Shared GET handler — returns result data for a booking. */
+export function createResultGetHandler(stepLabel: string) {
+  return withParticipationGetHandler(stepLabel, ({ participation }) =>
+    NextResponse.json({
+      success: true,
+      data: {
+        resultOutcome: participation.resultOutcome,
+        resultNotes: participation.resultNotes,
+        resultCompletedAt: participation.resultCompletedAt,
+        status: participation.status,
+        isComplete: participation.status === 'COMPLETE',
+      },
+    })
+  );
+}
+
+/** Shared PUT handler factory — accepts localized messages. */
+export function createResultPutHandler(
+  stepLabel: string,
+  messages: { complete: string; saved: string }
+) {
+  return withParticipationMutationHandler(
+    stepLabel,
+    resultStepSchema,
+    async ({
+      participation,
+      body,
+      userId,
+      bookingId,
+    }: ParticipationRouteContext & {
+      body: z.infer<typeof resultStepSchema>;
+    }) => {
+      const { complete, ...resultData } = body;
+
+      await updateResult(participation.id, resultData);
+
+      if (complete) {
+        await completeResultStep(participation.id);
+        serverInstance.info('Participation completed', {
+          userId,
+          bookingId,
+          participationId: participation.id,
+          courseTitle: participation.booking.course.title,
+        });
+      }
+
+      return NextResponse.json({
+        success: true,
+        message: complete ? messages.complete : messages.saved,
+      });
+    }
+  );
+}

--- a/app/api/my-courses/[bookingId]/result/route.ts
+++ b/app/api/my-courses/[bookingId]/result/route.ts
@@ -5,156 +5,17 @@
  * PUT - Update result data (save/complete - final step)
  */
 
-import { auth } from '@clerk/nextjs/server';
-import { type NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
 import {
-  completeResultStep,
-  getParticipationByBookingId,
-  updateResult,
-} from '../../../../../lib/db/courseParticipation';
-import { serverInstance } from '../../../../../lib/monitoring/rollbar-official';
+  createResultGetHandler,
+  createResultPutHandler,
+} from './result-handlers';
 
-// Zod schema for result input
-const resultSchema = z.object({
-  resultOutcome: z.string().max(2000).optional(),
-  resultNotes: z.string().max(2000).optional(),
-  complete: z.boolean().optional(),
-});
+export const GET = createResultGetHandler('/api/my-courses/[bookingId]/result');
 
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
-
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized result access', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
-    return NextResponse.json({
-      success: true,
-      data: {
-        resultOutcome: participation.resultOutcome,
-        resultNotes: participation.resultNotes,
-        resultCompletedAt: participation.resultCompletedAt,
-        status: participation.status,
-        isComplete: participation.status === 'COMPLETE',
-      },
-    });
-  } catch (error) {
-    serverInstance.error('Error in GET /api/my-courses/[bookingId]/result', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+export const PUT = createResultPutHandler(
+  '/api/my-courses/[bookingId]/result',
+  {
+    complete: 'Participation completed',
+    saved: 'Data saved',
   }
-}
-
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
-
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    // Parse and validate body
-    const body = await request.json();
-    const parseResult = resultSchema.safeParse(body);
-
-    if (!parseResult.success) {
-      return NextResponse.json(
-        { error: 'Invalid data', details: parseResult.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { complete, ...resultData } = parseResult.data;
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized result update', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
-    // Update result data
-    await updateResult(participation.id, resultData);
-
-    // If completing, mark entire participation as complete
-    if (complete) {
-      await completeResultStep(participation.id);
-      serverInstance.info('Participation completed', {
-        userId,
-        bookingId,
-        participationId: participation.id,
-        courseTitle: participation.booking.course.title,
-      });
-    }
-
-    return NextResponse.json({
-      success: true,
-      message: complete ? 'Participation completed' : 'Data saved',
-    });
-  } catch (error) {
-    serverInstance.error('Error in PUT /api/my-courses/[bookingId]/result', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
-  }
-}
+);

--- a/app/api/my-courses/[bookingId]/results/route.ts
+++ b/app/api/my-courses/[bookingId]/results/route.ts
@@ -1,208 +1,26 @@
 /**
- * Results Step API Route
+ * Results Step API Route (German-localized variant of result)
  *
  * GET - Retrieve results data for a booking
  * PUT - Update results data (save/complete - final step)
+ *
+ * Shares handlers with `../result/route.ts` via `../result/result-handlers.ts`.
+ * Only the user-facing messages differ (German informal "Du").
  */
 
-import { auth } from '@clerk/nextjs/server';
-import { type NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
 import {
-  completeResultStep,
-  getParticipationByBookingId,
-  updateResult,
-} from '../../../../../lib/db/courseParticipation';
-import { serverInstance } from '../../../../../lib/monitoring/rollbar-official';
+  createResultGetHandler,
+  createResultPutHandler,
+} from '../result/result-handlers';
 
-// Zod schema for results input
-const resultsSchema = z.object({
-  resultOutcome: z.string().max(2000).optional(),
-  resultNotes: z.string().max(2000).optional(),
-  complete: z.boolean().optional(),
-});
+export const GET = createResultGetHandler(
+  '/api/my-courses/[bookingId]/results'
+);
 
-/**
- * Type guard to validate bookingId parameter
- * Ensures bookingId is a non-empty string
- */
-function isValidBookingId(bookingId: unknown): bookingId is string {
-  return typeof bookingId === 'string' && bookingId.trim().length > 0;
-}
-
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json(
-        { error: 'Nicht authentifiziert' },
-        { status: 401 }
-      );
-    }
-
-    // Robustly parse and validate params
-    let resolvedParams: { bookingId: string };
-    try {
-      resolvedParams = await params;
-    } catch (error) {
-      serverInstance.error('Failed to resolve params in GET results', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return NextResponse.json(
-        { error: 'Ungültige Anfrageparameter' },
-        { status: 400 }
-      );
-    }
-
-    const { bookingId } = resolvedParams;
-    if (!isValidBookingId(bookingId)) {
-      return NextResponse.json(
-        { error: 'Booking ID ist erforderlich und muss gültig sein' },
-        { status: 400 }
-      );
-    }
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Teilnahme nicht gefunden' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized results access', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json(
-        { error: 'Keine Berechtigung' },
-        { status: 403 }
-      );
-    }
-
-    return NextResponse.json({
-      success: true,
-      data: {
-        resultOutcome: participation.resultOutcome,
-        resultNotes: participation.resultNotes,
-        resultCompletedAt: participation.resultCompletedAt,
-        status: participation.status,
-        isComplete: participation.status === 'COMPLETE',
-      },
-    });
-  } catch (error) {
-    serverInstance.error('Error in GET /api/my-courses/[bookingId]/results', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return NextResponse.json(
-      { error: 'Interner Serverfehler' },
-      { status: 500 }
-    );
+export const PUT = createResultPutHandler(
+  '/api/my-courses/[bookingId]/results',
+  {
+    complete: 'Teilnahme abgeschlossen',
+    saved: 'Daten gespeichert',
   }
-}
-
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json(
-        { error: 'Nicht authentifiziert' },
-        { status: 401 }
-      );
-    }
-
-    // Robustly parse and validate params
-    let resolvedParams: { bookingId: string };
-    try {
-      resolvedParams = await params;
-    } catch (error) {
-      serverInstance.error('Failed to resolve params in PUT results', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return NextResponse.json(
-        { error: 'Ungültige Anfrageparameter' },
-        { status: 400 }
-      );
-    }
-
-    const { bookingId } = resolvedParams;
-    if (!isValidBookingId(bookingId)) {
-      return NextResponse.json(
-        { error: 'Booking ID ist erforderlich und muss gültig sein' },
-        { status: 400 }
-      );
-    }
-
-    // Parse and validate body
-    const body = await request.json();
-    const parseResult = resultsSchema.safeParse(body);
-
-    if (!parseResult.success) {
-      return NextResponse.json(
-        { error: 'Ungültige Daten', details: parseResult.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { complete, ...resultsData } = parseResult.data;
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Teilnahme nicht gefunden' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized results update', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json(
-        { error: 'Keine Berechtigung' },
-        { status: 403 }
-      );
-    }
-
-    // Update results data
-    await updateResult(participation.id, resultsData);
-
-    // If completing, mark entire participation as complete
-    if (complete) {
-      await completeResultStep(participation.id);
-      serverInstance.info('Participation completed', {
-        userId,
-        bookingId,
-        participationId: participation.id,
-        courseTitle: participation.booking.course.title,
-      });
-    }
-
-    return NextResponse.json({
-      success: true,
-      message: complete ? 'Teilnahme abgeschlossen' : 'Daten gespeichert',
-    });
-  } catch (error) {
-    serverInstance.error('Error in PUT /api/my-courses/[bookingId]/results', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return NextResponse.json(
-      { error: 'Interner Serverfehler' },
-      { status: 500 }
-    );
-  }
-}
+);

--- a/app/api/my-courses/[bookingId]/resume/route.ts
+++ b/app/api/my-courses/[bookingId]/resume/route.ts
@@ -6,52 +6,22 @@
  * GET - Get active resume metadata
  */
 
-import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import {
+  resolveParticipation,
+  withParticipationGetHandler,
+} from '@/lib/api/participation-route-handler';
 import {
   createResumeDocument,
   deactivateResumeDocument,
   getActiveResume,
-  getParticipationByBookingId,
-} from '../../../../../lib/db/courseParticipation';
-import { serverInstance } from '../../../../../lib/monitoring/rollbar-official';
-import {
-  deleteResume,
-  uploadResume,
-} from '../../../../../lib/utils/resumeUpload';
+} from '@/lib/db/courseParticipation';
+import { serverInstance } from '@/lib/monitoring/rollbar-official';
+import { deleteResume, uploadResume } from '@/lib/utils/resumeUpload';
 
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
-
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
+export const GET = withParticipationGetHandler(
+  '/api/my-courses/[bookingId]/resume',
+  async ({ participation }) => {
     const activeResume = await getActiveResume(participation.id);
 
     return NextResponse.json({
@@ -66,55 +36,19 @@ export async function GET(
           }
         : null,
     });
-  } catch (error) {
-    serverInstance.error('Error in GET /api/my-courses/[bookingId]/resume', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ bookingId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
+    const resolution = await resolveParticipation(params, 'resume upload');
+    if (!resolution.ok) return resolution.response;
 
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
+    const { userId, bookingId, participation } = resolution;
 
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized resume upload attempt', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
-    // Parse multipart form data
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
 
@@ -122,7 +56,6 @@ export async function POST(
       return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
     }
 
-    // Upload to Vercel Blob
     const uploadResult = await uploadResume(file, participation.id, userId);
 
     if (!uploadResult.success) {
@@ -132,7 +65,6 @@ export async function POST(
       );
     }
 
-    // Save to database (handles deactivating previous)
     const document = await createResumeDocument({
       participationId: participation.id,
       blobUrl: uploadResult.blobUrl!,
@@ -177,32 +109,10 @@ export async function DELETE(
   { params }: { params: Promise<{ bookingId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
+    const resolution = await resolveParticipation(params, 'resume deletion');
+    if (!resolution.ok) return resolution.response;
 
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
+    const { userId, bookingId, participation } = resolution;
 
     const activeResume = await getActiveResume(participation.id);
 
@@ -213,14 +123,12 @@ export async function DELETE(
       );
     }
 
-    // Delete from Vercel Blob
     await deleteResume(activeResume.blobUrl, {
       participationId: participation.id,
       userId,
       reason: 'User requested deletion via API',
     });
 
-    // Deactivate in database
     await deactivateResumeDocument(activeResume.id);
 
     serverInstance.info('Resume deleted successfully', {

--- a/app/api/my-courses/[bookingId]/summary/route.ts
+++ b/app/api/my-courses/[bookingId]/summary/route.ts
@@ -5,61 +5,27 @@
  * PUT - Mark summary as viewed/completed
  */
 
-import { auth } from '@clerk/nextjs/server';
-import { type NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
+  withParticipationGetHandler,
+  withParticipationMutationHandler,
+} from '@/lib/api/participation-route-handler';
+import {
   completeSummaryStep,
-  getParticipationByBookingId,
   getResolvedSummaryAssets,
   recordSummaryPresented,
-} from '../../../../../lib/db/courseParticipation';
-import { serverInstance } from '../../../../../lib/monitoring/rollbar-official';
+} from '@/lib/db/courseParticipation';
+import { serverInstance } from '@/lib/monitoring/rollbar-official';
 
-// Zod schema for summary update
 const summaryUpdateSchema = z.object({
   markViewed: z.boolean().optional(),
   complete: z.boolean().optional(),
 });
 
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
-
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized summary access', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
-    // Get resolved summary assets
+export const GET = withParticipationGetHandler(
+  '/api/my-courses/[bookingId]/summary',
+  async ({ participation }) => {
     const assets = await getResolvedSummaryAssets(
       participation.id,
       participation.courseId
@@ -76,68 +42,15 @@ export async function GET(
         hasAssets: assets.length > 0,
       },
     });
-  } catch (error) {
-    serverInstance.error('Error in GET /api/my-courses/[bookingId]/summary', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);
 
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ bookingId: string }> }
-) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
+export const PUT = withParticipationMutationHandler(
+  '/api/my-courses/[bookingId]/summary',
+  summaryUpdateSchema,
+  async ({ participation, body, userId, bookingId }) => {
+    const { markViewed, complete } = body;
 
-    const { bookingId } = await params;
-    if (!bookingId) {
-      return NextResponse.json(
-        { error: 'Booking ID is required' },
-        { status: 400 }
-      );
-    }
-
-    // Parse and validate body
-    const body = await request.json();
-    const parseResult = summaryUpdateSchema.safeParse(body);
-
-    if (!parseResult.success) {
-      return NextResponse.json(
-        { error: 'Invalid data', details: parseResult.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { markViewed, complete } = parseResult.data;
-
-    const participation = await getParticipationByBookingId(bookingId);
-
-    if (!participation) {
-      return NextResponse.json(
-        { error: 'Participation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Verify ownership
-    if (participation.booking.userId !== userId) {
-      serverInstance.warning('Unauthorized summary update', {
-        userId,
-        bookingId,
-        ownerId: participation.booking.userId,
-      });
-      return NextResponse.json({ error: 'No permission' }, { status: 403 });
-    }
-
-    // Mark as viewed if requested
     if (markViewed && !participation.summaryPresentedAt) {
       const assets = await getResolvedSummaryAssets(
         participation.id,
@@ -155,7 +68,6 @@ export async function PUT(
       }
     }
 
-    // Complete step if requested
     if (complete) {
       await completeSummaryStep(participation.id);
       serverInstance.info('Summary step completed', {
@@ -169,13 +81,5 @@ export async function PUT(
       success: true,
       message: complete ? 'Summary completed' : 'Updated',
     });
-  } catch (error) {
-    serverInstance.error('Error in PUT /api/my-courses/[bookingId]/summary', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);

--- a/lib/api/participation-route-handler.ts
+++ b/lib/api/participation-route-handler.ts
@@ -1,0 +1,209 @@
+/**
+ * Shared route handler for participation step routes.
+ *
+ * Eliminates the duplicated auth → ownership → error-handling boilerplate
+ * that was repeated across the six `app/api/my-courses/[bookingId]/*` routes.
+ */
+
+import { auth } from '@clerk/nextjs/server';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import type { z } from 'zod';
+import type { ParticipationWithRelations } from '@/lib/db/courseParticipation';
+import { getParticipationByBookingId } from '@/lib/db/courseParticipation';
+import { serverInstance } from '@/lib/monitoring/rollbar-official';
+
+/** Context passed to step handlers after auth + ownership checks succeed. */
+export interface ParticipationRouteContext {
+  userId: string;
+  bookingId: string;
+  participation: ParticipationWithRelations;
+  request: NextRequest;
+}
+
+/** Result of the shared auth + ownership + participation resolution. */
+type ParticipationResolution =
+  | {
+      ok: true;
+      userId: string;
+      bookingId: string;
+      participation: ParticipationWithRelations;
+    }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Authenticate the user, resolve the participation by bookingId, and verify
+ * ownership. Returns either a successful context or an error NextResponse
+ * that the caller should return as-is.
+ */
+export async function resolveParticipation(
+  params: Promise<{ bookingId: string }>,
+  stepLabel: string
+): Promise<ParticipationResolution> {
+  const { userId } = await auth();
+  if (!userId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Not authenticated' },
+        { status: 401 }
+      ),
+    };
+  }
+
+  let bookingId: string;
+  try {
+    ({ bookingId } = await params);
+  } catch (error) {
+    serverInstance.error(`Failed to resolve params in ${stepLabel}`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Invalid request parameters' },
+        { status: 400 }
+      ),
+    };
+  }
+
+  if (!bookingId || bookingId.trim().length === 0) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Booking ID is required' },
+        { status: 400 }
+      ),
+    };
+  }
+
+  const participation = await getParticipationByBookingId(bookingId);
+
+  if (!participation) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Participation not found' },
+        { status: 404 }
+      ),
+    };
+  }
+
+  if (participation.booking.userId !== userId) {
+    serverInstance.warning(`Unauthorized ${stepLabel} access`, {
+      userId,
+      bookingId,
+      ownerId: participation.booking.userId,
+    });
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'No permission' }, { status: 403 }),
+    };
+  }
+
+  return { ok: true, userId, bookingId, participation };
+}
+
+/**
+ * Wrap a GET handler for a participation step route.
+ *
+ * The handler receives the authenticated context and returns a NextResponse
+ * (or a Promise of one). Auth, participation resolution, ownership check,
+ * and error handling are handled centrally.
+ */
+export function withParticipationGetHandler(
+  stepLabel: string,
+  handler: (
+    ctx: ParticipationRouteContext
+  ) => NextResponse | Promise<NextResponse>
+): (
+  request: NextRequest,
+  params: { params: Promise<{ bookingId: string }> }
+) => Promise<NextResponse> {
+  return async (request, { params }) => {
+    try {
+      const resolution = await resolveParticipation(params, stepLabel);
+      if (!resolution.ok) return resolution.response;
+
+      return await handler({
+        userId: resolution.userId,
+        bookingId: resolution.bookingId,
+        participation: resolution.participation,
+        request,
+      });
+    } catch (error) {
+      serverInstance.error(`Error in GET ${stepLabel}`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return NextResponse.json(
+        { error: 'Internal server error' },
+        { status: 500 }
+      );
+    }
+  };
+}
+
+/**
+ * Wrap a PUT/PATCH/POST handler for a participation step route.
+ *
+ * Parses and validates the request body against the provided Zod schema before
+ * invoking the handler. Auth, participation resolution, ownership check,
+ * validation, and error handling are handled centrally.
+ */
+export function withParticipationMutationHandler<TBody extends z.ZodTypeAny>(
+  stepLabel: string,
+  schema: TBody,
+  handler: (
+    ctx: ParticipationRouteContext & {
+      body: z.infer<TBody>;
+    }
+  ) => NextResponse | Promise<NextResponse>
+): (
+  request: NextRequest,
+  params: { params: Promise<{ bookingId: string }> }
+) => Promise<NextResponse> {
+  return async (request, { params }) => {
+    try {
+      const resolution = await resolveParticipation(params, stepLabel);
+      if (!resolution.ok) return resolution.response;
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return NextResponse.json(
+          { error: 'Invalid JSON body' },
+          { status: 400 }
+        );
+      }
+
+      const parseResult = schema.safeParse(body);
+
+      if (!parseResult.success) {
+        return NextResponse.json(
+          {
+            error: 'Invalid data',
+            details: parseResult.error.flatten(),
+          },
+          { status: 400 }
+        );
+      }
+
+      return await handler({
+        userId: resolution.userId,
+        bookingId: resolution.bookingId,
+        participation: resolution.participation,
+        request,
+        body: parseResult.data,
+      });
+    } catch (error) {
+      serverInstance.error(`Error in ${request.method} ${stepLabel}`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return NextResponse.json(
+        { error: 'Internal server error' },
+        { status: 500 }
+      );
+    }
+  };
+}

--- a/tests/unit/api/participation-route-handler.spec.ts
+++ b/tests/unit/api/participation-route-handler.spec.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for the shared participation route handler.
+ *
+ * Covers the central authorization path in resolveParticipation and the
+ * wrapper functions withParticipationGetHandler and
+ * withParticipationMutationHandler.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock auth from @clerk/nextjs/server
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+}));
+
+// Mock getParticipationByBookingId
+const mockGetParticipationByBookingId = vi.fn();
+vi.mock('@/lib/db/courseParticipation', () => ({
+  getParticipationByBookingId: (...args: unknown[]) =>
+    mockGetParticipationByBookingId(...args),
+}));
+
+// Mock serverInstance to avoid Rollbar side effects
+vi.mock('@/lib/monitoring/rollbar-official', () => ({
+  serverInstance: {
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { auth } from '@clerk/nextjs/server';
+import {
+  resolveParticipation,
+  withParticipationGetHandler,
+  withParticipationMutationHandler,
+} from '@/lib/api/participation-route-handler';
+import { z } from 'zod';
+import { NextResponse } from 'next/server';
+
+const mockAuth = vi.mocked(auth);
+
+/** Build a minimal participation object for tests. */
+function makeParticipation(ownerId = 'user-123') {
+  return {
+    id: 'part-1',
+    bookingId: 'booking-1',
+    courseId: 'course-1',
+    booking: {
+      id: 'booking-1',
+      userId: ownerId,
+      paymentStatus: 'PAID',
+      course: {
+        id: 'course-1',
+        title: 'Test Course',
+        slug: 'test-course',
+        startDate: null,
+      },
+    },
+    documents: [],
+    summaryOverrides: [],
+  } as unknown as Parameters<
+    typeof mockGetParticipationByBookingId
+  >[0] extends never
+    ? never
+    : Awaited<ReturnType<typeof mockGetParticipationByBookingId>>;
+}
+
+describe('resolveParticipation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when userId is missing', async () => {
+    mockAuth.mockResolvedValue({ userId: null } as never);
+    mockGetParticipationByBookingId.mockResolvedValue(null);
+
+    const result = await resolveParticipation(
+      Promise.resolve({ bookingId: 'booking-1' }),
+      'test-step'
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  it('returns 400 when bookingId is empty', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-123' } as never);
+
+    const result = await resolveParticipation(
+      Promise.resolve({ bookingId: '' }),
+      'test-step'
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+    }
+  });
+
+  it('returns 404 when participation is not found', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-123' } as never);
+    mockGetParticipationByBookingId.mockResolvedValue(null);
+
+    const result = await resolveParticipation(
+      Promise.resolve({ bookingId: 'booking-1' }),
+      'test-step'
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(404);
+    }
+  });
+
+  it('returns 403 when booking belongs to another user', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-123' } as never);
+    mockGetParticipationByBookingId.mockResolvedValue(
+      makeParticipation('other-user')
+    );
+
+    const result = await resolveParticipation(
+      Promise.resolve({ bookingId: 'booking-1' }),
+      'test-step'
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(403);
+    }
+  });
+
+  it('returns ok with userId and participation when valid', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-123' } as never);
+    const participation = makeParticipation('user-123');
+    mockGetParticipationByBookingId.mockResolvedValue(participation);
+
+    const result = await resolveParticipation(
+      Promise.resolve({ bookingId: 'booking-1' }),
+      'test-step'
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.userId).toBe('user-123');
+      expect(result.bookingId).toBe('booking-1');
+      expect(result.participation).toBe(participation);
+    }
+  });
+});
+
+describe('withParticipationGetHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls handler with context when auth + ownership succeed', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-123' } as never);
+    const participation = makeParticipation('user-123');
+    mockGetParticipationByBookingId.mockResolvedValue(participation);
+
+    const handler = vi.fn().mockResolvedValue(
+      NextResponse.json({ success: true })
+    );
+
+    const routeHandler = withParticipationGetHandler('test-step', handler);
+
+    const request = new Request('http://localhost/api/test') as never;
+    const response = await routeHandler(request, {
+      params: Promise.resolve({ bookingId: 'booking-1' }),
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-123',
+        bookingId: 'booking-1',
+        participation,
+      })
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it('returns 401 without calling handler when not authenticated', async () => {
+    mockAuth.mockResolvedValue({ userId: null } as never);
+
+    const handler = vi.fn();
+    const routeHandler = withParticipationGetHandler('test-step', handler);
+
+    const request = new Request('http://localhost/api/test') as never;
+    const response = await routeHandler(request, {
+      params: Promise.resolve({ bookingId: 'booking-1' }),
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('withParticipationMutationHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const schema = z.object({
+    value: z.string(),
+  });
+
+  it('calls handler with parsed body when valid', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-123' } as never);
+    const participation = makeParticipation('user-123');
+    mockGetParticipationByBookingId.mockResolvedValue(participation);
+
+    const handler = vi.fn().mockResolvedValue(
+      NextResponse.json({ success: true })
+    );
+
+    const routeHandler = withParticipationMutationHandler(
+      'test-step',
+      schema,
+      handler
+    );
+
+    const request = new Request('http://localhost/api/test', {
+      method: 'PUT',
+      body: JSON.stringify({ value: 'hello' }),
+    }) as never;
+    const response = await routeHandler(request, {
+      params: Promise.resolve({ bookingId: 'booking-1' }),
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: { value: 'hello' },
+      })
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it('returns 400 when JSON body is malformed', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-123' } as never);
+    const participation = makeParticipation('user-123');
+    mockGetParticipationByBookingId.mockResolvedValue(participation);
+
+    const handler = vi.fn();
+    const routeHandler = withParticipationMutationHandler(
+      'test-step',
+      schema,
+      handler
+    );
+
+    const request = new Request('http://localhost/api/test', {
+      method: 'PUT',
+      body: 'not-json',
+    }) as never;
+    const response = await routeHandler(request, {
+      params: Promise.resolve({ bookingId: 'booking-1' }),
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when schema validation fails', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-123' } as never);
+    const participation = makeParticipation('user-123');
+    mockGetParticipationByBookingId.mockResolvedValue(participation);
+
+    const handler = vi.fn();
+    const routeHandler = withParticipationMutationHandler(
+      'test-step',
+      schema,
+      handler
+    );
+
+    const request = new Request('http://localhost/api/test', {
+      method: 'PUT',
+      body: JSON.stringify({ wrongField: 123 }),
+    }) as never;
+    const response = await routeHandler(request, {
+      params: Promise.resolve({ bookingId: 'booking-1' }),
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

Eliminates code duplication across API routes to bring Codacy duplication metric below threshold.

## Changes

### Shared participation route handler (new)
- `lib/api/participation-route-handler.ts` — `withParticipationGetHandler` and `withParticipationMutationHandler` wrapping auth→401→getParticipation→404→ownership→403→zod→try/catch→500
- `resolveParticipation` exported for reuse by non-standard routes (resume POST/DELETE)

### 6 my-courses/[bookingId]/* routes migrated
- `preparation`, `summary`, `debriefing`, `result`, `results`, `resume` — each shrunk from ~150-200 lines to ~20-50 lines
- `result` and `results` consolidated via shared `result-handlers.ts` module (preserves DE/EN localized messages)
- `resume` POST/DELETE now use shared `resolveParticipation` instead of local `resolveForResume`

### 3 admin routes migrated
- `admin/bookings/[id]/review` — 13× `Object.entries(corsHeaders).forEach()` → `applyCorsHeaders()`; raw `auth()` → `requireAdminUser()`
- `admin/bookings/pending` — 6× CORS boilerplate removed; raw `auth()` → `requireAdminUser()`
- `admin/users/[id]` — 15× `Object.entries(corsHeaders).forEach()` → `applyCorsHeaders()`

### Tests
- `tests/unit/api/participation-route-handler.spec.ts` — 10 tests covering 401/400/404/403/ok, GET wrapper, mutation wrapper, malformed JSON, schema validation

### Push prompt
- Removed invalid `model` frontmatter from `push.prompt.md` (VS Code uses model picker default)

## Stats
- **+912 / -1151** lines (net -239)
- 13 files changed, 3 new files

## Verification
- ✅ Lint (biome): clean
- ✅ Tests: 295 passed, 56 skipped, 0 failed
- ✅ Type errors: none
- ✅ Codacy: all files clean